### PR TITLE
Article, Scrap 생성

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   ignorePatterns: ['.eslintrc.js'],
   rules: {
+    'import/no-unresolved': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express';
+
+const publish = async (req: Request, res: Response) => {
+  res.status(200).send(req.body);
+};
+
+export default { publish };

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -5,12 +5,12 @@ import scrapService from '@apis/scrap/scrap.service';
 import articleService from './article.service';
 
 const publish = async (req: Request, res: Response) => {
-  const { title, contents, book_id } = req.body;
-  const article = await articleService.createArticle(title, contents, book_id);
+  const article = await articleService.createArticle(req.body);
+
   const scrap = await scrapService.createScrap({
     order: 1,
     is_original: true,
-    book_id,
+    book_id: article.book_id,
     article_id: article.id,
   });
 

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -1,7 +1,12 @@
 import { Request, Response } from 'express';
 
+import articleService from './article.service';
+
 const publish = async (req: Request, res: Response) => {
-  res.status(200).send(req.body);
+  const { title, contents, book_id } = req.body;
+  const article = await articleService.createArticle(title, contents, book_id);
+
+  res.status(200).send({ article });
 };
 
 export default { publish };

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -1,12 +1,20 @@
 import { Request, Response } from 'express';
 
+import scrapService from '@apis/scrap/scrap.service';
+
 import articleService from './article.service';
 
 const publish = async (req: Request, res: Response) => {
   const { title, contents, book_id } = req.body;
   const article = await articleService.createArticle(title, contents, book_id);
+  const scrap = await scrapService.createScrap({
+    order: 1,
+    is_original: true,
+    book_id,
+    article_id: article.id,
+  });
 
-  res.status(200).send({ article });
+  res.status(200).send({ article, scrap });
 };
 
 export default { publish };

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -5,12 +5,18 @@ import scrapService from '@apis/scrap/scrap.service';
 import articleService from './article.service';
 
 const publish = async (req: Request, res: Response) => {
-  const article = await articleService.createArticle(req.body);
+  const { title, contents, book_id, order } = req.body;
+
+  const article = await articleService.createArticle({
+    title,
+    contents,
+    book_id,
+  });
 
   const scrap = await scrapService.createScrap({
-    order: 1,
+    order,
     is_original: true,
-    book_id: article.book_id,
+    book_id,
     article_id: article.id,
   });
 

--- a/backend/src/apis/article/article.controller.ts
+++ b/backend/src/apis/article/article.controller.ts
@@ -20,7 +20,7 @@ const publish = async (req: Request, res: Response) => {
     article_id: article.id,
   });
 
-  res.status(200).send({ article, scrap });
+  res.status(201).send({ article, scrap });
 };
 
 export default { publish };

--- a/backend/src/apis/article/article.interface.ts
+++ b/backend/src/apis/article/article.interface.ts
@@ -1,0 +1,5 @@
+export interface CreateArticle {
+  title: string;
+  contents: string;
+  book_id: number;
+}

--- a/backend/src/apis/article/article.service.ts
+++ b/backend/src/apis/article/article.service.ts
@@ -1,7 +1,9 @@
+import { CreateArticle } from '@apis/article/article.interface';
 import { prisma } from '@config/orm.config';
 
-const createArticle = async (title: string, contents: string, book_id: number) => {
-  console.log(title, 111);
+const createArticle = async (dto: CreateArticle) => {
+  const { title, contents, book_id } = dto;
+
   const article = await prisma.article.create({
     data: {
       title,
@@ -13,6 +15,7 @@ const createArticle = async (title: string, contents: string, book_id: number) =
       },
     },
   });
+
   return article;
 };
 

--- a/backend/src/apis/article/article.service.ts
+++ b/backend/src/apis/article/article.service.ts
@@ -1,0 +1,21 @@
+import { prisma } from '@config/orm.config';
+
+const createArticle = async (title: string, contents: string, book_id: number) => {
+  console.log(title, 111);
+  const article = await prisma.article.create({
+    data: {
+      title,
+      contents,
+      book: {
+        connect: {
+          id: book_id,
+        },
+      },
+    },
+  });
+  return article;
+};
+
+export default {
+  createArticle,
+};

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 
+import articleController from '@apis/article/article.controller';
 import authController from '@apis/auth/auth.controller';
 import { catchAsync } from '@utils/catch-async';
 
@@ -7,5 +8,7 @@ const router = Router();
 
 router.post('/auth/signin/local', catchAsync(authController.signIn));
 router.post('/auth/signin/github', catchAsync(authController.signInGithub));
+
+router.post('/articles', catchAsync(articleController.publish));
 
 export default router;

--- a/backend/src/apis/scrap/scrap.interface.ts
+++ b/backend/src/apis/scrap/scrap.interface.ts
@@ -1,0 +1,6 @@
+export interface CreateScrap {
+  order: number;
+  is_original: boolean;
+  book_id: number;
+  article_id: number;
+}

--- a/backend/src/apis/scrap/scrap.service.ts
+++ b/backend/src/apis/scrap/scrap.service.ts
@@ -1,14 +1,9 @@
+import { CreateScrap } from '@apis/scrap/scrap.interface';
 import { prisma } from '@config/orm.config';
 
-interface createScrapProps {
-  order: number;
-  is_original: boolean;
-  book_id: number;
-  article_id: number;
-}
-
-const createScrap = async (dto: createScrapProps) => {
+const createScrap = async (dto: CreateScrap) => {
   const { order, is_original, book_id, article_id } = dto;
+
   const scrap = await prisma.scrap.create({
     data: {
       order,

--- a/backend/src/apis/scrap/scrap.service.ts
+++ b/backend/src/apis/scrap/scrap.service.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@config/orm.config';
+
+interface createScrapProps {
+  order: number;
+  is_original: boolean;
+  book_id: number;
+  article_id: number;
+}
+
+const createScrap = async (dto: createScrapProps) => {
+  const { order, is_original, book_id, article_id } = dto;
+  const scrap = await prisma.scrap.create({
+    data: {
+      order,
+      is_original,
+      book: {
+        connect: {
+          id: book_id,
+        },
+      },
+      article: {
+        connect: {
+          id: article_id,
+        },
+      },
+    },
+  });
+
+  return scrap;
+};
+
+export default {
+  createScrap,
+};


### PR DESCRIPTION
## 개요

에디터 페이지에서 발행 버튼을 눌렀을 때 글과 스크랩을 생성하고 그 결과를 리턴해줌

## 변경 사항

*`backend`*
- `apis` / `arictle` 도메인
- `apis` / `scrap` 도메인

## 참고 사항

- 관련 이슈에서 추가 검증 사항을 어디까지 반영해야 할지 몰라서 적어는 놨는데 어디까지 고려를 해봐야 할지
- interface로 dto 활용을 간단하게 해봤는데 적합할지

## 스크린샷

![image](https://user-images.githubusercontent.com/67371123/203259224-7ddddf21-685c-4729-89fd-ff2ff57e0fbb.png)


## 관련 이슈

- closes #67
