### PR TITLE
회원가입 모달 UI 작업 및 모달 이동 구현

### DIFF
--- a/frontend/components/SignInModal/index.tsx
+++ b/frontend/components/SignInModal/index.tsx
@@ -2,13 +2,12 @@ import Image from 'next/image';
 
 import { useState } from 'react';
 
-import axios from 'axios';
-
 import GithubIcon from '@assets/ico_github.svg';
 import LabeledInput from '@components/common/LabeledInput';
 import Button from '@components/common/Modal/ModalButton';
+import axios from 'axios';
 
-import SignInModalWrapper from './styled';
+import { SignInModalWrapper, SignInModalSignUpContainer, SignUpButton } from './styled';
 
 export default function SignInModal() {
   const [info, setInfo] = useState({
@@ -70,6 +69,10 @@ export default function SignInModal() {
         <Image src={GithubIcon} alt="Github Icon" />
         Github으로 로그인하기
       </Button>
+      <SignInModalSignUpContainer>
+        <div>아직 계정이 없으신가요?</div>
+        <SignUpButton>회원가입하기</SignUpButton>
+      </SignInModalSignUpContainer>
     </SignInModalWrapper>
   );
 }

--- a/frontend/components/SignInModal/index.tsx
+++ b/frontend/components/SignInModal/index.tsx
@@ -9,7 +9,11 @@ import axios from 'axios';
 
 import { SignInModalWrapper, SignInModalSignUpContainer, SignUpButton } from './styled';
 
-export default function SignInModal() {
+export default function SignInModal({
+  handleGoToSignUpBtnClicked,
+}: {
+  handleGoToSignUpBtnClicked: () => void;
+}) {
   const [info, setInfo] = useState({
     username: '',
     password: '',
@@ -71,7 +75,7 @@ export default function SignInModal() {
       </Button>
       <SignInModalSignUpContainer>
         <div>아직 계정이 없으신가요?</div>
-        <SignUpButton>회원가입하기</SignUpButton>
+        <SignUpButton onClick={handleGoToSignUpBtnClicked}>회원가입하기</SignUpButton>
       </SignInModalSignUpContainer>
     </SignInModalWrapper>
   );

--- a/frontend/components/SignInModal/styled.ts
+++ b/frontend/components/SignInModal/styled.ts
@@ -1,6 +1,7 @@
+import { FlexColumnCenter } from '@styles/layout';
 import styled from 'styled-components';
 
-const SignInModalWrapper = styled.div`
+export const SignInModalWrapper = styled.div`
   margin-top: 56px;
   display: flex;
   flex-direction: column;
@@ -8,4 +9,18 @@ const SignInModalWrapper = styled.div`
   box-sizing: border-box;
 `;
 
-export default SignInModalWrapper;
+export const SignInModalSignUpContainer = styled(FlexColumnCenter)`
+  padding: 20px;
+  gap: 10px;
+
+  border-top: 1px solid var(--title-active-color);
+
+  font-size: 14px;
+  color: var(--grey-01-color);
+`;
+
+export const SignUpButton = styled.button`
+  color: var(--primary-color);
+  font-size: 16px;
+  font-weight: 700;
+`;

--- a/frontend/components/SignUpModal/index.tsx
+++ b/frontend/components/SignUpModal/index.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+import LabeledInput from '@components/common/LabeledInput';
+import Button from '@components/common/Modal/ModalButton';
+import axios from 'axios';
+
+import SignUpModalWrapper from './styled';
+
+function SignUpModal() {
+  const [info, setInfo] = useState({
+    username: '',
+    password: '',
+    nickname: '',
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInfo({
+      ...info,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSignUpBtnClick = () => {
+    return ``;
+  };
+
+  return (
+    <SignUpModalWrapper>
+      <LabeledInput
+        label="아이디"
+        type="text"
+        name="username"
+        placeholder="아이디를 입력해주세요"
+        onChange={handleInputChange}
+      />
+      <LabeledInput
+        label="비밀번호"
+        type="password"
+        name="password"
+        placeholder="비밀번호를 입력해주세요"
+        onChange={handleInputChange}
+      />
+      <LabeledInput
+        label="닉네임"
+        type="text"
+        name="nickname"
+        placeholder="닉네임을 입력해주세요"
+        onChange={handleInputChange}
+      />
+      <Button theme="primary" onClick={handleSignUpBtnClick}>
+        회원가입하기
+      </Button>
+    </SignUpModalWrapper>
+  );
+}
+
+export default SignUpModal;

--- a/frontend/components/SignUpModal/styled.ts
+++ b/frontend/components/SignUpModal/styled.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const SignUpModalWrapper = styled.div`
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-sizing: border-box;
+`;
+
+export default SignUpModalWrapper;

--- a/frontend/components/common/GNB/index.tsx
+++ b/frontend/components/common/GNB/index.tsx
@@ -7,14 +7,21 @@ import PersonIcon from '@assets/ico_person.svg';
 import SearchIcon from '@assets/ico_search.svg';
 import Modal from '@components/common/Modal';
 import SignInModal from '@components/SignInModal';
+import SignUpModal from '@components/SignUpModal';
 
 import { GNBbar, IconsContainer, Logo } from './styled';
 
 export default function GNB() {
   const [isModalShown, setModalShown] = useState(false);
+  const [currentModalState, setCurrentModalState] = useState<'SignIn' | 'SignUp'>('SignIn');
 
   const handleModalOpen = () => setModalShown(true);
-  const handleModalClose = () => setModalShown(false);
+  const handleModalClose = () => {
+    setModalShown(false);
+    setCurrentModalState('SignIn');
+  };
+  const handleGoToSignUpBtnClicked = () => setCurrentModalState('SignUp');
+  const handleBackwardBtnClicked = () => setCurrentModalState('SignIn');
 
   return (
     <GNBbar>
@@ -26,11 +33,21 @@ export default function GNB() {
         <Image src={SearchIcon} alt="Search Icon" />
       </IconsContainer>
 
-      {isModalShown && (
-        <Modal title="Knoticle 시작하기" handleModalClose={handleModalClose}>
-          <SignInModal />
-        </Modal>
-      )}
+      {isModalShown &&
+        ((currentModalState === 'SignUp' && (
+          <Modal
+            title="Knoticle 시작하기"
+            handleModalClose={handleModalClose}
+            handleBackwardBtnClicked={handleBackwardBtnClicked}
+            hasBackward
+          >
+            <SignUpModal />
+          </Modal>
+        )) || (
+          <Modal title="Knoticle 시작하기" handleModalClose={handleModalClose}>
+            <SignInModal handleGoToSignUpBtnClicked={handleGoToSignUpBtnClicked} />
+          </Modal>
+        ))}
     </GNBbar>
   );
 }

--- a/frontend/components/common/Modal/index.tsx
+++ b/frontend/components/common/Modal/index.tsx
@@ -12,15 +12,22 @@ interface ModalProps {
   children: React.ReactNode;
 
   handleModalClose: () => void;
+  handleBackwardBtnClicked?: () => void;
 }
 
-export default function Modal({ title, hasBackward, children, handleModalClose }: ModalProps) {
+export default function Modal({
+  title,
+  hasBackward,
+  children,
+  handleModalClose,
+  handleBackwardBtnClicked,
+}: ModalProps) {
   return (
     <ModalWrapper>
       <Dimmed onClick={handleModalClose} />
       <ModalInner>
         <ButtonWrapper hasBackward={hasBackward}>
-          <Image src={BackwardIcon} alt="Backward Icon" />
+          <Image src={BackwardIcon} alt="Backward Icon" onClick={handleBackwardBtnClicked} />
           <Image src={CancelIcon} alt="Cancel Icon" onClick={handleModalClose} />
         </ButtonWrapper>
         <ModalTitle>
@@ -34,4 +41,5 @@ export default function Modal({ title, hasBackward, children, handleModalClose }
 
 Modal.defaultProps = {
   hasBackward: false,
+  handleBackwardBtnClicked: undefined,
 };


### PR DESCRIPTION
## 개요
- 로그인 모달 UI 작업 완료 (회원가입 버튼 추가)
- 회원가입 모달 UI 작업
- 로그인 모달에서 회원가입하기 버튼 클릭 시 회원가입 모달로 이동


## 변경 사항
- SignUpModal 컴포넌트 추가
- SignInModal 컴포넌트에 회원가입 버튼 추가
- 뒤로가기, 회원가입 버튼 이벤트 핸들러 등록

## 스크린샷

- 로그인 모달 완성

![loginmodalcomplete](https://user-images.githubusercontent.com/109179856/203273160-b16efcd1-d89f-4721-9f1e-af37610c239b.JPG)

- 회원가입 모달

![joinModal](https://user-images.githubusercontent.com/109179856/203272983-9bd52639-1103-4159-bac1-955cb96becc7.JPG)


## 관련 이슈

closes #5 
closes #6 
closes #9 
