### PR TITLE
토큰 guard 미들웨어 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
         "aws-sdk": "^2.1259.0",
         "axios": "^1.1.3",
         "bcrypt": "^5.1.0",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
+        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.14",
         "@types/jsonwebtoken": "^8.5.9",
@@ -343,6 +345,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -1273,6 +1284,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5056,6 +5087,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -5741,6 +5781,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "aws-sdk": "^2.1259.0",
     "axios": "^1.1.3",
     "bcrypt": "^5.1.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.14",
     "@types/jsonwebtoken": "^8.5.9",

--- a/backend/src/apis/auth/auth.controller.ts
+++ b/backend/src/apis/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 
 import authService from '@apis/auth/auth.service';
 import { Unauthorized, Message } from '@errors';
+import token from '@utils/token';
 
 const signIn = async (req: Request, res: Response) => {
   const { username, password } = req.body;
@@ -11,9 +12,9 @@ const signIn = async (req: Request, res: Response) => {
 
   const user = await authService.getSignedUser(username, password);
 
-  const { accessToken, refreshToken } = authService.getTokens(user.id, user.nickname);
+  const { accessToken, refreshToken } = token.getTokens(user.id, user.nickname);
 
-  await authService.saveRefreshToken(user.id, refreshToken);
+  await token.saveRefreshToken(user.id, refreshToken);
 
   res.cookie('access_token', accessToken, { httpOnly: true });
   res.cookie('refresh_token', refreshToken, { httpOnly: true });
@@ -32,9 +33,9 @@ const signInGithub = async (req: Request, res: Response) => {
     (await authService.getUserByLocalDB(provider_id)) ||
     (await authService.signUpGithubUser(username, provider_id));
 
-  const { accessToken, refreshToken } = authService.getTokens(githubUser.id, githubUser.nickname);
+  const { accessToken, refreshToken } = token.getTokens(githubUser.id, githubUser.nickname);
 
-  await authService.saveRefreshToken(githubUser.id, refreshToken);
+  await token.saveRefreshToken(githubUser.id, refreshToken);
 
   res.cookie('access_token', accessToken, { httpOnly: true });
   res.cookie('refresh_token', refreshToken, { httpOnly: true });

--- a/backend/src/apis/auth/auth.service.ts
+++ b/backend/src/apis/auth/auth.service.ts
@@ -1,8 +1,8 @@
 import { prisma } from '@config/orm.config';
 import { ResourceConflict, Message, Unauthorized } from '@errors';
+import { generateJWT } from '@utils/token';
 import axios from 'axios';
 import { hash, compare } from 'bcrypt';
-import jwt from 'jsonwebtoken';
 
 const getSignedUser = async (username: string, password: string) => {
   const user = await prisma.user.findFirst({
@@ -32,14 +32,6 @@ const getTokens = (userId: number, nickname: string) => {
     accessToken,
     refreshToken,
   };
-};
-
-const generateJWT = (expiresIn: '3h' | '7d', payload: { id?: number; nickname?: string } = {}) => {
-  return jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn });
-};
-
-const decodeJWT = (token: string) => {
-  return jwt.verify(token, process.env.JWT_SECRET_KEY);
 };
 
 const saveRefreshToken = async (userId: number, refreshToken: string) => {

--- a/backend/src/apis/auth/auth.service.ts
+++ b/backend/src/apis/auth/auth.service.ts
@@ -1,6 +1,5 @@
 import { prisma } from '@config/orm.config';
 import { ResourceConflict, Message, Unauthorized } from '@errors';
-import { generateJWT } from '@utils/token';
 import axios from 'axios';
 import { hash, compare } from 'bcrypt';
 
@@ -22,31 +21,6 @@ const getSignedUser = async (username: string, password: string) => {
   if (!(await compare(password, user.password))) throw new Unauthorized(Message.AUTH_WRONG);
 
   return user;
-};
-
-const getTokens = (userId: number, nickname: string) => {
-  const accessToken = generateJWT('3h', { id: userId, nickname });
-  const refreshToken = generateJWT('7d');
-
-  return {
-    accessToken,
-    refreshToken,
-  };
-};
-
-const saveRefreshToken = async (userId: number, refreshToken: string) => {
-  await prisma.token.upsert({
-    where: {
-      user_id: userId,
-    },
-    update: {
-      refresh_token: refreshToken,
-    },
-    create: {
-      user_id: userId,
-      refresh_token: refreshToken,
-    },
-  });
 };
 
 const getGithubAccessToken = async (code: string) => {
@@ -160,8 +134,6 @@ const signUpLocalUser = async (username: string, password: string, nickname: str
 
 export default {
   getSignedUser,
-  getTokens,
-  saveRefreshToken,
   getGithubAccessToken,
   getUserByGithubAPI,
   getUserByLocalDB,

--- a/backend/src/errors/messages.ts
+++ b/backend/src/errors/messages.ts
@@ -5,4 +5,5 @@ export default {
   AUTH_NICKNAME_OVERLAP: '중복되는 닉네임이 존재합니다.',
   ARTICLE_NOTFOUND: '일치하는 글이 없습니다.',
   TOKEN_EXPIRED: '다시 로그인 해주세요',
+  TOKEN_MALFORMED: '다시 로그인 해주세요',
 };

--- a/backend/src/errors/messages.ts
+++ b/backend/src/errors/messages.ts
@@ -4,4 +4,5 @@ export default {
   AUTH_USERNAME_OVERLAP: '중복되는 아이디가 존재합니다.',
   AUTH_NICKNAME_OVERLAP: '중복되는 닉네임이 존재합니다.',
   ARTICLE_NOTFOUND: '일치하는 글이 없습니다.',
+  TOKEN_EXPIRED: '다시 로그인 해주세요',
 };

--- a/backend/src/loaders/express.loader.ts
+++ b/backend/src/loaders/express.loader.ts
@@ -1,9 +1,9 @@
 import { Application, ErrorRequestHandler, json, urlencoded } from 'express';
 
+import router from '@apis';
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import logger from 'morgan';
-
-import router from '@apis';
 
 const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
   const { status, message } = err;
@@ -16,6 +16,7 @@ export default (app: Application) => {
   app.use(json());
   app.use(urlencoded({ extended: false }));
   app.use(cors({ credentials: true, origin: process.env.ORIGIN_URL }));
+  app.use(cookieParser());
   app.use('/api', router);
   app.use(errorHandler);
 };

--- a/backend/src/middlewares/tokenValidator.ts
+++ b/backend/src/middlewares/tokenValidator.ts
@@ -1,17 +1,15 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { Unauthorized } from '@errors/index';
-import Message from '@errors/messages';
 import token from '@utils/token';
 
-const tokenValidator = async (req: Request, res: Response, next: NextFunction) => {
+const guard = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { id, nickname } = token.decodeJWT(req.cookies.access_token);
     res.locals.id = id;
     res.locals.nickname = nickname;
     next();
   } catch (err) {
-    const { accessToken, refreshToken, id, nickname } = await handleAccessTokenExpired(
+    const { accessToken, refreshToken, id, nickname } = await token.handleAccessTokenExpired(
       req.cookies.refresh_token
     );
     res.cookie('access_token', accessToken, { httpOnly: true });
@@ -23,20 +21,4 @@ const tokenValidator = async (req: Request, res: Response, next: NextFunction) =
   }
 };
 
-const handleAccessTokenExpired = async (refresh_token: string) => {
-  const matchedToken = await token.checkRefreshTokenValid(refresh_token);
-  if (!matchedToken) throw new Unauthorized(Message.TOKEN_EXPIRED);
-  else {
-    const newTokens = token.getTokens(matchedToken.user_id, matchedToken.user.nickname);
-
-    await token.saveRefreshToken(matchedToken.user_id, newTokens.refreshToken);
-
-    return {
-      ...newTokens,
-      id: matchedToken.user_id,
-      nickname: matchedToken.user.nickname,
-    };
-  }
-};
-
-export default tokenValidator;
+export default guard;

--- a/backend/src/middlewares/tokenValidator.ts
+++ b/backend/src/middlewares/tokenValidator.ts
@@ -1,0 +1,42 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { Unauthorized } from '@errors/index';
+import Message from '@errors/messages';
+import token from '@utils/token';
+
+const tokenValidator = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id, nickname } = token.decodeJWT(req.cookies.access_token);
+    res.locals.id = id;
+    res.locals.nickname = nickname;
+    next();
+  } catch (err) {
+    const { accessToken, refreshToken, id, nickname } = await handleAccessTokenExpired(
+      req.cookies.refresh_token
+    );
+    res.cookie('access_token', accessToken, { httpOnly: true });
+    res.cookie('refresh_token', refreshToken, { httpOnly: true });
+
+    res.locals.id = id;
+    res.locals.nickname = nickname;
+    next();
+  }
+};
+
+const handleAccessTokenExpired = async (refresh_token: string) => {
+  const matchedToken = await token.checkRefreshTokenValid(refresh_token);
+  if (!matchedToken) throw new Unauthorized(Message.TOKEN_EXPIRED);
+  else {
+    const newTokens = token.getTokens(matchedToken.user_id, matchedToken.user.nickname);
+
+    await token.saveRefreshToken(matchedToken.user_id, newTokens.refreshToken);
+
+    return {
+      ...newTokens,
+      id: matchedToken.user_id,
+      nickname: matchedToken.user.nickname,
+    };
+  }
+};
+
+export default tokenValidator;

--- a/backend/src/middlewares/tokenValidator.ts
+++ b/backend/src/middlewares/tokenValidator.ts
@@ -6,9 +6,7 @@ import token from '@utils/token';
 const guard = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { id, nickname } = token.verifyJWT(req.cookies.access_token);
-    res.locals.id = id;
-    res.locals.nickname = nickname;
-
+    res.locals.user = { id, nickname };
     next();
   } catch (err) {
     if (err.message === 'jwt expired') {
@@ -23,8 +21,7 @@ const guard = async (req: Request, res: Response, next: NextFunction) => {
       res.cookie('access_token', accessToken, { httpOnly: true });
       res.cookie('refresh_token', refreshToken, { httpOnly: true });
 
-      res.locals.id = id;
-      res.locals.nickname = nickname;
+      res.locals.user = { id, nickname };
 
       next();
     } else throw new Unauthorized(Message.TOKEN_MALFORMED);

--- a/backend/src/middlewares/tokenValidator.ts
+++ b/backend/src/middlewares/tokenValidator.ts
@@ -1,23 +1,33 @@
 import { NextFunction, Request, Response } from 'express';
 
+import { Unauthorized, Message } from '@errors';
 import token from '@utils/token';
 
 const guard = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { id, nickname } = token.decodeJWT(req.cookies.access_token);
+    const { id, nickname } = token.verifyJWT(req.cookies.access_token);
     res.locals.id = id;
     res.locals.nickname = nickname;
+
     next();
   } catch (err) {
-    const { accessToken, refreshToken, id, nickname } = await token.handleAccessTokenExpired(
-      req.cookies.refresh_token
-    );
-    res.cookie('access_token', accessToken, { httpOnly: true });
-    res.cookie('refresh_token', refreshToken, { httpOnly: true });
+    if (err.message === 'jwt expired') {
+      const { id, nickname } = token.decodeJWT(req.cookies.access_token);
 
-    res.locals.id = id;
-    res.locals.nickname = nickname;
-    next();
+      await token.checkRefreshTokenValid(req.cookies.refresh_token);
+
+      const { accessToken, refreshToken } = token.getTokens(id, nickname);
+
+      await token.saveRefreshToken(id, refreshToken);
+
+      res.cookie('access_token', accessToken, { httpOnly: true });
+      res.cookie('refresh_token', refreshToken, { httpOnly: true });
+
+      res.locals.id = id;
+      res.locals.nickname = nickname;
+
+      next();
+    } else throw new Unauthorized(Message.TOKEN_MALFORMED);
   }
 };
 

--- a/backend/src/utils/token.ts
+++ b/backend/src/utils/token.ts
@@ -1,12 +1,61 @@
-import jwt from 'jsonwebtoken';
+import { prisma } from '@config/orm.config';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 
-export const generateJWT = (
-  expiresIn: '3h' | '7d',
-  payload: { id?: number; nickname?: string } = {}
-) => {
+const generateJWT = (expiresIn: '3h' | '7d', payload: { id?: number; nickname?: string } = {}) => {
   return jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn });
 };
 
-export const decodeJWT = (token: string) => {
-  return jwt.verify(token, process.env.JWT_SECRET_KEY);
+const decodeJWT = (token: string) => {
+  return jwt.verify(token, process.env.JWT_SECRET_KEY) as JwtPayload;
+};
+
+const getTokens = (userId: number, nickname: string) => {
+  const accessToken = generateJWT('3h', { id: userId, nickname });
+  const refreshToken = generateJWT('7d');
+
+  return {
+    accessToken,
+    refreshToken,
+  };
+};
+
+const saveRefreshToken = async (userId: number, refreshToken: string) => {
+  await prisma.token.upsert({
+    where: {
+      user_id: userId,
+    },
+    update: {
+      refresh_token: refreshToken,
+    },
+    create: {
+      user_id: userId,
+      refresh_token: refreshToken,
+    },
+  });
+};
+
+const checkRefreshTokenValid = async (refresh_token: string) => {
+  const matchedToken = await prisma.token.findFirst({
+    where: {
+      refresh_token,
+    },
+    select: {
+      user_id: true,
+      user: {
+        select: {
+          nickname: true,
+        },
+      },
+    },
+  });
+  if (!matchedToken) return false;
+  return matchedToken;
+};
+
+export default {
+  generateJWT,
+  decodeJWT,
+  getTokens,
+  saveRefreshToken,
+  checkRefreshTokenValid,
 };

--- a/backend/src/utils/token.ts
+++ b/backend/src/utils/token.ts
@@ -48,7 +48,6 @@ const checkRefreshTokenValid = async (refresh_token: string) => {
       },
     },
   });
-  if (!matchedToken) return false;
   return matchedToken;
 };
 

--- a/backend/src/utils/token.ts
+++ b/backend/src/utils/token.ts
@@ -1,0 +1,12 @@
+import jwt from 'jsonwebtoken';
+
+export const generateJWT = (
+  expiresIn: '3h' | '7d',
+  payload: { id?: number; nickname?: string } = {}
+) => {
+  return jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn });
+};
+
+export const decodeJWT = (token: string) => {
+  return jwt.verify(token, process.env.JWT_SECRET_KEY);
+};


### PR DESCRIPTION
## 개요

토큰 guard 미들웨어 추가

## 변경 사항

- cookieparser 설치
- token 관련 함수 utils로 분리
- guard 미들웨어 추가

## 참고 사항

- 유효하지 않은 access token, 유효한 refresh token이 있을 시 새 토큰들을 발급받습니다.
- 두 토큰 모두 유효하지 않을 경우 unauthorized 에러를 발생시킵니다.
- access token이 유효할 경우 토큰을 해독하여 다음 미들웨어에서 **res.locals.id, res.locals.nickname으로 참조 가능**합니다.

## 관련 이슈

