### PR TITLE
책 조회 API에서 비로그인 유저 요청 시 발생하는 오류 수정

### DIFF
--- a/backend/src/apis/books/books.controller.ts
+++ b/backend/src/apis/books/books.controller.ts
@@ -5,7 +5,11 @@ import booksService from '@apis/books/books.service';
 const getBook = async (req: Request, res: Response) => {
   const { bookId } = req.params;
 
-  const book = await booksService.findBook(+bookId, res.locals?.user.id);
+  let userId = res.locals.user?.id;
+
+  if (!userId) userId = 0;
+
+  const book = await booksService.findBook(+bookId, userId);
 
   res.status(200).send(book);
 };
@@ -16,7 +20,11 @@ const getBooks = async (req: Request, res: Response) => {
     take: number;
   };
 
-  const books = await booksService.findBooks({ order, take: +take, userId: res.locals?.user.id });
+  let userId = res.locals.user?.id;
+
+  if (!userId) userId = 0;
+
+  const books = await booksService.findBooks({ order, take: +take, userId });
 
   res.status(200).send(books);
 };

--- a/backend/src/apis/books/books.service.ts
+++ b/backend/src/apis/books/books.service.ts
@@ -3,17 +3,6 @@ import { prisma } from '@config/orm.config';
 import { FindBooks } from './books.interface';
 
 const findBook = async (bookId: number, userId: number) => {
-  let additionalJoin = {};
-
-  if (userId)
-    additionalJoin = {
-      bookmarks: {
-        where: {
-          user_id: userId,
-        },
-      },
-    };
-
   const book = await prisma.book.findFirst({
     select: {
       id: true,
@@ -36,10 +25,14 @@ const findBook = async (bookId: number, userId: number) => {
           },
         },
       },
+      bookmarks: {
+        where: {
+          user_id: userId,
+        },
+      },
       _count: {
         select: { bookmarks: true },
       },
-      ...additionalJoin,
     },
     where: {
       id: bookId,
@@ -55,17 +48,6 @@ const findBooks = async ({ order, take, userId }: FindBooks) => {
 
   if (order === 'bookmark') sortOptions.push({ bookmarks: { _count: 'desc' as const } });
   if (order === 'newest') sortOptions.push({ created_at: 'desc' as const });
-
-  let additionalJoin = {};
-
-  if (userId)
-    additionalJoin = {
-      bookmarks: {
-        where: {
-          user_id: userId,
-        },
-      },
-    };
 
   const books = await prisma.book.findMany({
     select: {
@@ -89,10 +71,14 @@ const findBooks = async ({ order, take, userId }: FindBooks) => {
           },
         },
       },
+      bookmarks: {
+        where: {
+          user_id: userId,
+        },
+      },
       _count: {
         select: { bookmarks: true },
       },
-      ...additionalJoin,
     },
     where: {
       deleted_at: null,


### PR DESCRIPTION
## 개요

비로그인 상태에서 책 조회 API에 요청 했을 때 오류가 발생하는 현상 수정

## 변경 사항

- 액세스 토큰이 없는 경우 예외 처리

## 관련 이슈

- #52 
