### PR TITLE
뷰어페이지 글 컴포넌트 교체

### DIFF
--- a/frontend/components/viewer/ArticleContent/index.tsx
+++ b/frontend/components/viewer/ArticleContent/index.tsx
@@ -9,6 +9,7 @@ import LeftBtnIcon from '@assets/ico_leftBtn.svg';
 import Original from '@assets/ico_original.svg';
 import RightBtnIcon from '@assets/ico_rightBtn.svg';
 import Scrap from '@assets/ico_scrap.svg';
+import Content from '@components/common/Content';
 import { TextLarge } from '@styles/common';
 
 import ArticleButton from './Button';
@@ -48,7 +49,7 @@ interface articleProps {
 
 const user = {
   id: 1,
-  nickname: 'mocha',
+  nickname: 'moc1ha',
 };
 
 export default function Article({ article, scraps, bookId }: articleProps) {
@@ -79,7 +80,7 @@ export default function Article({ article, scraps, bookId }: articleProps) {
     }
   };
 
-  const checkArticleAuthority = (scraps: any, id: number) => {
+  const checkArticleAuthority = (id: number) => {
     if (scraps.find((v: scrapsData) => v.article.id === id)) {
       return true;
     }
@@ -91,7 +92,7 @@ export default function Article({ article, scraps, bookId }: articleProps) {
   };
 
   useEffect(() => {
-    checkArticleAuthority(scraps, article.id);
+    checkArticleAuthority(article.id);
   }, []);
 
   return (
@@ -125,7 +126,7 @@ export default function Article({ article, scraps, bookId }: articleProps) {
               </ArticleButton>
             </ArticleTitleBtnBox>
           </ArticleTitle>
-          <ArticleContents>{article.content}</ArticleContents>
+          <Content content={article.content} />
         </ArticleMain>
       ) : (
         <ArticleMain>삭제된 글입니다.</ArticleMain>

--- a/frontend/components/viewer/TOC/index.tsx
+++ b/frontend/components/viewer/TOC/index.tsx
@@ -29,10 +29,11 @@ interface TocProps {
 }
 
 export default function TOC({ articleId, book, handleSideBarOnClick }: TocProps) {
+  const { id, title, user, scraps, _count, bookmarks } = book;
   const { handleBookmarkClick, curBookmarkCnt, curBookmarkId } = useBookmark(
-    book.bookmarks.length ? book.bookmarks[0].id : null,
-    book._count.bookmarks,
-    book.id
+    bookmarks.length ? bookmarks[0].id : null,
+    _count.bookmarks,
+    id
   );
 
   return (
@@ -48,15 +49,15 @@ export default function TOC({ articleId, book, handleSideBarOnClick }: TocProps)
           <Image src={Hide} alt="Closed Sidebar Icon" onClick={handleSideBarOnClick} />
         </TocIcons>
         <TextSmall>{curBookmarkCnt}</TextSmall>
-        <TocTitle>{book.title}</TocTitle>
+        <TocTitle>{title}</TocTitle>
 
         <TocContainer>
           <TextMedium>목차</TextMedium>
           <TocList>
-            {book.scraps.map((v) => {
+            {scraps.map((v) => {
               return (
                 <TocArticle
-                  href={`/viewer/${book.id}/${v.article.id}`}
+                  href={`/viewer/${id}/${v.article.id}`}
                   key={v.order}
                   className={v.article.id === articleId ? 'current' : ''}
                 >
@@ -70,7 +71,7 @@ export default function TOC({ articleId, book, handleSideBarOnClick }: TocProps)
       <TocProfile>
         <TocProfileText>
           <TextSmall>Written by</TextSmall>
-          <TextMedium>{book.user.nickname}</TextMedium>
+          <TextMedium>{user.nickname}</TextMedium>
         </TocProfileText>
         <TocImgWrapper src={SampleProflie} alt="Viewer Icon" />
       </TocProfile>

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -6,11 +6,11 @@ import styled, { keyframes } from 'styled-components';
 import { Flex } from '@styles/layout';
 
 const slide = keyframes`
-from {
-    left:-200px;
+0% {
+    width:0px;
 }
-to {
-    left:0px;
+100% {
+    width:250px;
 }
 `;
 
@@ -22,7 +22,7 @@ export const TocWrapper = styled(Flex)`
   color: var(--white-color);
   flex-direction: column;
   position: relative;
-  animation: ${slide} 1s ease-in-out;
+  // animation: ${slide} 1s ease-in-out;
 `;
 
 export const TocSideBar = styled.div`


### PR DESCRIPTION
## 개요

뷰어페이지 글 컴포넌트 교체

## 변경 사항

- 뷰어페이지 글 컴포넌트를 에디터의 프리뷰와 동일한 컴포넌트로 교체(tag 적용)
- 사이드바 애니메이션 제거
-TOC book 구조분해할당 사용

## 참고 사항

- 사이드바 애니메이션은 우선 주석처리했습니다.

## 스크린샷

![스크린샷 2022-11-24 오후 7 01 30](https://user-images.githubusercontent.com/87806611/203755130-0eaf9259-a2cd-40b1-a824-62e8a16cc2bd.png)


## 관련 이슈

- #98 
