### PR TITLE
Editor 컴포넌트 이미지 붙여넣기 작업

### DIFF
--- a/frontend/apis/imageApi.ts
+++ b/frontend/apis/imageApi.ts
@@ -1,0 +1,13 @@
+import api from '@utils/api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const createImageApi = async (data: FormData) => {
+  const url = `/api/image`;
+  const header = {
+    'Content-Type': 'multipart/form-data',
+  };
+
+  const response = await api({ url, method: 'POST', header, data });
+
+  return response.data;
+};

--- a/frontend/components/common/Content/styled.ts
+++ b/frontend/components/common/Content/styled.ts
@@ -39,4 +39,10 @@ export const ContentBody = styled.div`
     list-style-type: disc;
     list-style-position: inside;
   }
+
+  p {
+    img {
+      width: 100%;
+    }
+  }
 `;

--- a/frontend/components/edit/Editor/core/theme.ts
+++ b/frontend/components/edit/Editor/core/theme.ts
@@ -1,0 +1,24 @@
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags } from '@lezer/highlight';
+
+export default function theme() {
+  const highlightStyle = HighlightStyle.define([
+    {
+      tag: tags.heading1,
+      'font-size': '24px',
+      'font-weight': '700',
+    },
+    {
+      tag: tags.heading2,
+      'font-size': '20px',
+      'font-weight': '700',
+    },
+    {
+      tag: tags.heading3,
+      'font-size': '16px',
+      'font-weight': '700',
+    },
+  ]);
+
+  return [syntaxHighlighting(highlightStyle)];
+}

--- a/frontend/components/edit/Editor/core/useCodeMirror.ts
+++ b/frontend/components/edit/Editor/core/useCodeMirror.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { EditorState } from '@codemirror/state';
+import { placeholder } from '@codemirror/view';
+import { EditorView } from 'codemirror';
+
+import theme from './theme';
+
+export default function useCodeMirror() {
+  const [value, setValue] = useState('');
+  const [element, setElement] = useState<HTMLElement>();
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    if (!node) return;
+
+    setElement(node);
+  }, []);
+
+  function onChange() {
+    return EditorView.updateListener.of(({ view, docChanged }) => {
+      if (docChanged) setValue(view.state.doc.toString());
+
+      // console.log(view.state.selection.main.head);
+      // console.log(view.state.doc.lineAt(view.state.selection.main.head).number);
+    });
+  }
+
+  useEffect(() => {
+    if (!element) return;
+
+    const editorState = EditorState.create({
+      extensions: [
+        markdown({ base: markdownLanguage }),
+        placeholder('내용을 입력해주세요.'),
+        theme(),
+        onChange(),
+      ],
+    });
+
+    const view = new EditorView({
+      state: editorState,
+      parent: element,
+    });
+
+    // eslint-disable-next-line consistent-return
+    return () => view?.destroy();
+  }, [element]);
+
+  return { ref, value };
+}

--- a/frontend/components/edit/Editor/core/useCodeMirror.ts
+++ b/frontend/components/edit/Editor/core/useCodeMirror.ts
@@ -40,7 +40,7 @@ export default function useCodeMirror() {
         // eslint-disable-next-line no-restricted-syntax
         for (const item of items) {
           if (item.kind === 'file' && /image\/[png,jpg,jpeg,gif]/.test(item.type)) {
-            const blob = item.getAsFile();
+            const blob = item.getAsFile() as Blob;
 
             const formData = new FormData();
 
@@ -58,7 +58,7 @@ export default function useCodeMirror() {
 
     const cursor = editorView.state.selection.main.head;
 
-    const markdownImage = (path: string) => `![image](${path})`;
+    const markdownImage = (path: string) => `![image](${path})\n`;
 
     const insert = markdownImage(image.imagePath);
 

--- a/frontend/components/edit/Editor/index.tsx
+++ b/frontend/components/edit/Editor/index.tsx
@@ -6,14 +6,17 @@ import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { tags } from '@lezer/highlight';
 import { createTheme } from '@uiw/codemirror-themes';
+import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 
+import { createImageApi } from '@apis/imageApi';
 import articleState from '@atoms/article';
 import Content from '@components/common/Content';
+import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
 
 import { CodeMirrorWrapper, EditorInner, EditorWrapper, TitleInput } from './styled';
@@ -23,35 +26,14 @@ const CodeMirror = dynamic(() => import('@uiw/react-codemirror'), {
 });
 
 export default function Editor() {
+  const { data: imagePath, execute: createImage } = useFetch(createImageApi);
+
   const [article, setArticle] = useRecoilState(articleState);
 
   const [content, setContent] = useState('');
   const [height, setHeight] = useState(0);
 
   const title = useInput();
-
-  useEffect(() => {
-    setHeight(window.innerHeight - 68);
-  }, []);
-
-  useEffect(() => {
-    setArticle({
-      ...article,
-      title: title.value,
-    });
-  }, [title.value]);
-
-  useEffect(() => {
-    setArticle({
-      ...article,
-      content: unified()
-        .use(remarkParse)
-        .use(remarkRehype)
-        .use(rehypeStringify)
-        .processSync(content)
-        .toString(),
-    });
-  }, [content]);
 
   const theme = createTheme({
     theme: 'light',
@@ -79,6 +61,52 @@ export default function Editor() {
     ],
   });
 
+  useEffect(() => {
+    setHeight(window.innerHeight - 68);
+  }, []);
+
+  useEffect(() => {
+    setArticle({
+      ...article,
+      title: title.value,
+    });
+  }, [title.value]);
+
+  useEffect(() => {
+    setArticle({
+      ...article,
+      content: unified()
+        .use(remarkParse)
+        .use(remarkRehype)
+        .use(rehypeStringify)
+        .processSync(content)
+        .toString(),
+    });
+  }, [content]);
+
+  useEffect(() => {
+    console.log(imagePath);
+  }, [imagePath]);
+
+  const handleImagePaste = (event: ClipboardEvent) => {
+    if (!event.clipboardData) return;
+
+    const { items } = event.clipboardData;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const item of items) {
+      if (item.kind === 'file' && /image\/[png,jpg,jpeg,gif]/.test(item.type)) {
+        const blob = item.getAsFile();
+
+        const formData = new FormData();
+
+        formData.append('image', blob);
+
+        createImage(formData);
+      }
+    }
+  };
+
   return (
     <EditorWrapper style={{ height }}>
       <EditorInner>
@@ -101,6 +129,7 @@ export default function Editor() {
               highlightActiveLine: false,
             }}
             placeholder="내용을 입력해주세요"
+            onPasteCapture={(event) => handleImagePaste(event)}
           />
         </CodeMirrorWrapper>
       </EditorInner>

--- a/frontend/components/edit/Editor/index.tsx
+++ b/frontend/components/edit/Editor/index.tsx
@@ -6,22 +6,18 @@ import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 
-import { createImageApi } from '@apis/imageApi';
 import articleState from '@atoms/article';
 import Content from '@components/common/Content';
 import useCodeMirror from '@components/edit/Editor/core/useCodeMirror';
-import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
 
 import { CodeMirrorWrapper, EditorInner, EditorWrapper, TitleInput } from './styled';
 
 export default function Editor() {
-  const { data: imagePath, execute: createImage } = useFetch(createImageApi);
+  const { ref, value } = useCodeMirror();
 
   const [article, setArticle] = useRecoilState(articleState);
-
   const [height, setHeight] = useState(0);
-
   const title = useInput();
 
   useEffect(() => {
@@ -34,31 +30,6 @@ export default function Editor() {
       title: title.value,
     });
   }, [title.value]);
-
-  useEffect(() => {
-    console.log(imagePath);
-  }, [imagePath]);
-
-  const handleImagePaste = (event: ClipboardEvent) => {
-    if (!event.clipboardData) return;
-
-    const { items } = event.clipboardData;
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const item of items) {
-      if (item.kind === 'file' && /image\/[png,jpg,jpeg,gif]/.test(item.type)) {
-        const blob = item.getAsFile();
-
-        const formData = new FormData();
-
-        formData.append('image', blob);
-
-        createImage(formData);
-      }
-    }
-  };
-
-  const { ref, value } = useCodeMirror();
 
   useEffect(() => {
     setArticle({

--- a/frontend/components/edit/Editor/index.tsx
+++ b/frontend/components/edit/Editor/index.tsx
@@ -1,12 +1,5 @@
-import dynamic from 'next/dynamic';
-
 import { useEffect, useState } from 'react';
 
-import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
-import { languages } from '@codemirror/language-data';
-import { tags } from '@lezer/highlight';
-import { createTheme } from '@uiw/codemirror-themes';
-import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
@@ -16,50 +9,20 @@ import { unified } from 'unified';
 import { createImageApi } from '@apis/imageApi';
 import articleState from '@atoms/article';
 import Content from '@components/common/Content';
+import useCodeMirror from '@components/edit/Editor/core/useCodeMirror';
 import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
 
 import { CodeMirrorWrapper, EditorInner, EditorWrapper, TitleInput } from './styled';
-
-const CodeMirror = dynamic(() => import('@uiw/react-codemirror'), {
-  ssr: false,
-});
 
 export default function Editor() {
   const { data: imagePath, execute: createImage } = useFetch(createImageApi);
 
   const [article, setArticle] = useRecoilState(articleState);
 
-  const [content, setContent] = useState('');
   const [height, setHeight] = useState(0);
 
   const title = useInput();
-
-  const theme = createTheme({
-    theme: 'light',
-    settings: {
-      background: '#ffffff',
-      foreground: '#222222',
-      fontFamily: 'Noto Sans KR',
-    },
-    styles: [
-      {
-        tag: tags.heading1,
-        'font-size': '24px',
-        'font-weight': '700',
-      },
-      {
-        tag: tags.heading2,
-        'font-size': '20px',
-        'font-weight': '700',
-      },
-      {
-        tag: tags.heading3,
-        'font-size': '16px',
-        'font-weight': '700',
-      },
-    ],
-  });
 
   useEffect(() => {
     setHeight(window.innerHeight - 68);
@@ -71,18 +34,6 @@ export default function Editor() {
       title: title.value,
     });
   }, [title.value]);
-
-  useEffect(() => {
-    setArticle({
-      ...article,
-      content: unified()
-        .use(remarkParse)
-        .use(remarkRehype)
-        .use(rehypeStringify)
-        .processSync(content)
-        .toString(),
-    });
-  }, [content]);
 
   useEffect(() => {
     console.log(imagePath);
@@ -107,30 +58,26 @@ export default function Editor() {
     }
   };
 
+  const { ref, value } = useCodeMirror();
+
+  useEffect(() => {
+    setArticle({
+      ...article,
+      content: unified()
+        .use(remarkParse)
+        .use(remarkRehype)
+        .use(rehypeStringify)
+        .processSync(value)
+        .toString(),
+    });
+  }, [value]);
+
   return (
     <EditorWrapper style={{ height }}>
       <EditorInner>
         <TitleInput placeholder="제목을 입력해주세요" {...title} />
         <CodeMirrorWrapper>
-          <CodeMirror
-            value={content}
-            onChange={(value) => setContent(value)}
-            theme={theme}
-            extensions={[
-              markdown({
-                base: markdownLanguage,
-                codeLanguages: languages,
-              }),
-            ]}
-            basicSetup={{
-              lineNumbers: false,
-              foldGutter: false,
-              highlightSelectionMatches: false,
-              highlightActiveLine: false,
-            }}
-            placeholder="내용을 입력해주세요"
-            onPasteCapture={(event) => handleImagePaste(event)}
-          />
+          <div ref={ref} />
         </CodeMirrorWrapper>
       </EditorInner>
       <EditorInner>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,14 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.0.5",
-        "@codemirror/language-data": "^6.1.0",
+        "@codemirror/language": "^6.3.1",
+        "@codemirror/state": "^6.1.4",
+        "@codemirror/view": "^6.6.0",
         "@lezer/highlight": "^1.1.2",
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
-        "@uiw/codemirror-themes": "^4.15.1",
-        "@uiw/react-codemirror": "^4.15.1",
         "axios": "^1.1.3",
+        "codemirror": "^6.0.1",
         "dotenv": "^16.0.3",
         "dotenv-webpack": "^8.0.1",
         "eslint": "8.27.0",
@@ -34,6 +35,7 @@
         "unified": "^10.1.2"
       },
       "devDependencies": {
+        "@types/codemirror": "^5.60.5",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
@@ -346,15 +348,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-cpp": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.2.tgz",
-      "integrity": "sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/cpp": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.1.tgz",
@@ -381,15 +374,6 @@
         "@lezer/html": "^1.1.0"
       }
     },
-    "node_modules/@codemirror/lang-java": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.1.tgz",
-      "integrity": "sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/java": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.1.tgz",
@@ -402,15 +386,6 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-json": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
-      "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-markdown": {
@@ -426,71 +401,6 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-php": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.1.tgz",
-      "integrity": "sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/php": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-python": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.0.tgz",
-      "integrity": "sha512-a/JhyPYn5qz5T8WtAfZCuAZcfClgNVb7UZzdLr76bWUeG7Usd3Un5o8UQOkZ/5Xw+EM5YGHHG+T6ickMYkDcRQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/python": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-rust": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.1.tgz",
-      "integrity": "sha512-344EMWFBzWArHWdZn/NcgkwMvZIWUR1GEBdwG8FEp++6o6vT6KL9V7vGs2ONsKxxFUPXKI0SPcWhyYyl2zPYxQ==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/rust": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-sql": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.3.3.tgz",
-      "integrity": "sha512-VNsHju8500fkiDyDU8jZyGQ8M0iXU0SmfeCoCeAYkACcEFlX63BOT8311pICXyw43VYRbS23w54RgSEQmixGjQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-wast": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.1.tgz",
-      "integrity": "sha512-sQLsqhRjl2MWG3rxZysX+2XAyed48KhLBHLgq9xcKxIJu3npH/G+BIXW5NM5mHeDUjG0jcGh9BcjP0NfMStuzA==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-xml": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.1.tgz",
-      "integrity": "sha512-0tvycUTElajCcRKgsszhKjWX+uuOogdu5+enpfqYA+j0gnP8ek7LRxujh2/XMPRdXt/hwOML4slJLE7r2eX3yQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/xml": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/language": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.3.1.tgz",
@@ -502,36 +412,6 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language-data": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.1.0.tgz",
-      "integrity": "sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==",
-      "dependencies": {
-        "@codemirror/lang-cpp": "^6.0.0",
-        "@codemirror/lang-css": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-java": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.0.0",
-        "@codemirror/lang-json": "^6.0.0",
-        "@codemirror/lang-markdown": "^6.0.0",
-        "@codemirror/lang-php": "^6.0.0",
-        "@codemirror/lang-python": "^6.0.0",
-        "@codemirror/lang-rust": "^6.0.0",
-        "@codemirror/lang-sql": "^6.0.0",
-        "@codemirror/lang-wast": "^6.0.0",
-        "@codemirror/lang-xml": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/legacy-modes": "^6.1.0"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.3.0.tgz",
-      "integrity": "sha512-54ncmguzXZQ3u+8gx4/mpBRbkn6TLzfIrCGvFNLgB3giFYY3E2UETzv1RCFP0hM2L2bQBKBoI92i4ahrDAiE6g==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -559,21 +439,10 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.4.tgz",
       "integrity": "sha512-g+3OJuRylV5qsXuuhrc6Cvs1NQluNioepYMM2fhnpYkNk7NgX+j0AFuevKSVKzTDmDyt9+Puju+zPdHNECzCNQ=="
     },
-    "node_modules/@codemirror/theme-one-dark": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
-      "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/view": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.5.1.tgz",
-      "integrity": "sha512-xBKP8N3AXOs06VcKvIuvIQoUlGs7Hb78ftJWahLaRX909jKPMgGxR5XjvrawzTTZMSTU3DzdjDNPwG6fPM/ypQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.6.0.tgz",
+      "integrity": "sha512-40VaFVZI3rkyjO5GHFAbNwaW+YgZexjKyx5gxLU2DvfuXAEZX0kW0apOXb0SBRLnKIQJ+U/n2nPfxgBVFHERrg==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -713,15 +582,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
       "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw=="
     },
-    "node_modules/@lezer/cpp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.0.0.tgz",
-      "integrity": "sha512-Klk3/AIEKoptmm6cNm7xTulNXjdTKkD+hVOEcz/NeRg8tIestP5hsGHJeFDR/XtyDTxsjoPjKZRIGohht7zbKw==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@lezer/css": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.1.tgz",
@@ -749,28 +609,10 @@
         "@lezer/lr": "^1.0.0"
       }
     },
-    "node_modules/@lezer/java": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.0.0.tgz",
-      "integrity": "sha512-z2EA0JHq2WoiKfQy5uOOd4t17PJtq8guh58gPkSzOnNcQ7DNbkrU+Axak+jL8+Noinwyz2tRNOseQFj+Tg+P0A==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@lezer/javascript": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.1.1.tgz",
       "integrity": "sha512-bPsN0nria42StUTU6AZmYFDm/jDXAwMWT1x2EuiNfwVEZlJGJezie1r1wJIvEtw6zoRph3fo0adLxiis1mgh/Q==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
-      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
@@ -791,42 +633,6 @@
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/php": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.0.tgz",
-      "integrity": "sha512-kFQu/mk/vmjpA+fjQU87d9eimqKJ9PFCa8CZCPFWGEwNnm7Ahpw32N+HYEU/YAQ0XcfmOAnW/YJCEa8WpUOMMw==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/python": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.1.tgz",
-      "integrity": "sha512-ArUGh9kvdaOVu6IkSaYUS9WFQeMAFVWKRuZo6vexnxoeCLnxf0Y9DCFEAMMa7W9SQBGYE55OarSpPqSkdOXSCA==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/rust": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.0.tgz",
-      "integrity": "sha512-IpGAxIjNxYmX9ra6GfQTSPegdCAWNeq23WNmrsMMQI7YNSvKtYxO4TX5rgZUmbhEucWn0KTBMeDEPXg99YKtTA==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/xml": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
-      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -1102,6 +908,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -1133,8 +948,7 @@
     "node_modules/@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "peer": true
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -1225,6 +1039,15 @@
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1434,66 +1257,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.15.1.tgz",
-      "integrity": "sha512-LP2LHyPQm6ikYyXxT+1Odz+kiVLzzUmHSwBapSF4JgUE4b5QaBA7KCiTfwIWJPC528QVP2qWk1DEBNstPMiUdg==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": ">=6.0.0",
-        "@codemirror/commands": ">=6.0.0",
-        "@codemirror/language": ">=6.0.0",
-        "@codemirror/lint": ">=6.0.0",
-        "@codemirror/search": ">=6.0.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0"
-      }
-    },
-    "node_modules/@uiw/codemirror-themes": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.15.1.tgz",
-      "integrity": "sha512-+3NKdmptuZTGE56LQ3j8daOAKer2STEDklkJS9AGHAGoN1o7IdA+s2Pbp3hf5oGxukNb29UA+gskfb5grszWMg==",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/language": ">=6.0.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0"
-      }
-    },
-    "node_modules/@uiw/react-codemirror": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.15.1.tgz",
-      "integrity": "sha512-lgtMFS8D2t9ri3ug3kgWoLPPdxDkqkYBWm3dVU9Z7GRs4R1iN2WSr2Z/biQ8KbdyLygRT5isi1k3Ud9ZY6j+YA==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.15.1",
-        "codemirror": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": ">=7.11.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/theme-one-dark": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0",
-        "codemirror": ">=6.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6251,15 +6014,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "@codemirror/lang-cpp": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.2.tgz",
-      "integrity": "sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/cpp": "^1.0.0"
-      }
-    },
     "@codemirror/lang-css": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.1.tgz",
@@ -6286,15 +6040,6 @@
         "@lezer/html": "^1.1.0"
       }
     },
-    "@codemirror/lang-java": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.1.tgz",
-      "integrity": "sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/java": "^1.0.0"
-      }
-    },
     "@codemirror/lang-javascript": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.1.tgz",
@@ -6307,15 +6052,6 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-json": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
-      "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/json": "^1.0.0"
       }
     },
     "@codemirror/lang-markdown": {
@@ -6331,71 +6067,6 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
-    "@codemirror/lang-php": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.1.tgz",
-      "integrity": "sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==",
-      "requires": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/php": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-python": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.0.tgz",
-      "integrity": "sha512-a/JhyPYn5qz5T8WtAfZCuAZcfClgNVb7UZzdLr76bWUeG7Usd3Un5o8UQOkZ/5Xw+EM5YGHHG+T6ickMYkDcRQ==",
-      "requires": {
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/python": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-rust": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.1.tgz",
-      "integrity": "sha512-344EMWFBzWArHWdZn/NcgkwMvZIWUR1GEBdwG8FEp++6o6vT6KL9V7vGs2ONsKxxFUPXKI0SPcWhyYyl2zPYxQ==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/rust": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-sql": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.3.3.tgz",
-      "integrity": "sha512-VNsHju8500fkiDyDU8jZyGQ8M0iXU0SmfeCoCeAYkACcEFlX63BOT8311pICXyw43VYRbS23w54RgSEQmixGjQ==",
-      "requires": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-wast": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.1.tgz",
-      "integrity": "sha512-sQLsqhRjl2MWG3rxZysX+2XAyed48KhLBHLgq9xcKxIJu3npH/G+BIXW5NM5mHeDUjG0jcGh9BcjP0NfMStuzA==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@codemirror/lang-xml": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.1.tgz",
-      "integrity": "sha512-0tvycUTElajCcRKgsszhKjWX+uuOogdu5+enpfqYA+j0gnP8ek7LRxujh2/XMPRdXt/hwOML4slJLE7r2eX3yQ==",
-      "requires": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/xml": "^1.0.0"
-      }
-    },
     "@codemirror/language": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.3.1.tgz",
@@ -6407,36 +6078,6 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
-      }
-    },
-    "@codemirror/language-data": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.1.0.tgz",
-      "integrity": "sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==",
-      "requires": {
-        "@codemirror/lang-cpp": "^6.0.0",
-        "@codemirror/lang-css": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-java": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.0.0",
-        "@codemirror/lang-json": "^6.0.0",
-        "@codemirror/lang-markdown": "^6.0.0",
-        "@codemirror/lang-php": "^6.0.0",
-        "@codemirror/lang-python": "^6.0.0",
-        "@codemirror/lang-rust": "^6.0.0",
-        "@codemirror/lang-sql": "^6.0.0",
-        "@codemirror/lang-wast": "^6.0.0",
-        "@codemirror/lang-xml": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/legacy-modes": "^6.1.0"
-      }
-    },
-    "@codemirror/legacy-modes": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.3.0.tgz",
-      "integrity": "sha512-54ncmguzXZQ3u+8gx4/mpBRbkn6TLzfIrCGvFNLgB3giFYY3E2UETzv1RCFP0hM2L2bQBKBoI92i4ahrDAiE6g==",
-      "requires": {
-        "@codemirror/language": "^6.0.0"
       }
     },
     "@codemirror/lint": {
@@ -6464,21 +6105,10 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.4.tgz",
       "integrity": "sha512-g+3OJuRylV5qsXuuhrc6Cvs1NQluNioepYMM2fhnpYkNk7NgX+j0AFuevKSVKzTDmDyt9+Puju+zPdHNECzCNQ=="
     },
-    "@codemirror/theme-one-dark": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
-      "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
-      }
-    },
     "@codemirror/view": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.5.1.tgz",
-      "integrity": "sha512-xBKP8N3AXOs06VcKvIuvIQoUlGs7Hb78ftJWahLaRX909jKPMgGxR5XjvrawzTTZMSTU3DzdjDNPwG6fPM/ypQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.6.0.tgz",
+      "integrity": "sha512-40VaFVZI3rkyjO5GHFAbNwaW+YgZexjKyx5gxLU2DvfuXAEZX0kW0apOXb0SBRLnKIQJ+U/n2nPfxgBVFHERrg==",
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -6593,15 +6223,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
       "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw=="
     },
-    "@lezer/cpp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.0.0.tgz",
-      "integrity": "sha512-Klk3/AIEKoptmm6cNm7xTulNXjdTKkD+hVOEcz/NeRg8tIestP5hsGHJeFDR/XtyDTxsjoPjKZRIGohht7zbKw==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "@lezer/css": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.1.tgz",
@@ -6629,28 +6250,10 @@
         "@lezer/lr": "^1.0.0"
       }
     },
-    "@lezer/java": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.0.0.tgz",
-      "integrity": "sha512-z2EA0JHq2WoiKfQy5uOOd4t17PJtq8guh58gPkSzOnNcQ7DNbkrU+Axak+jL8+Noinwyz2tRNOseQFj+Tg+P0A==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "@lezer/javascript": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.1.1.tgz",
       "integrity": "sha512-bPsN0nria42StUTU6AZmYFDm/jDXAwMWT1x2EuiNfwVEZlJGJezie1r1wJIvEtw6zoRph3fo0adLxiis1mgh/Q==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@lezer/json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
-      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
       "requires": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
@@ -6671,42 +6274,6 @@
       "requires": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
-      }
-    },
-    "@lezer/php": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.0.tgz",
-      "integrity": "sha512-kFQu/mk/vmjpA+fjQU87d9eimqKJ9PFCa8CZCPFWGEwNnm7Ahpw32N+HYEU/YAQ0XcfmOAnW/YJCEa8WpUOMMw==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@lezer/python": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.1.tgz",
-      "integrity": "sha512-ArUGh9kvdaOVu6IkSaYUS9WFQeMAFVWKRuZo6vexnxoeCLnxf0Y9DCFEAMMa7W9SQBGYE55OarSpPqSkdOXSCA==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@lezer/rust": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.0.tgz",
-      "integrity": "sha512-IpGAxIjNxYmX9ra6GfQTSPegdCAWNeq23WNmrsMMQI7YNSvKtYxO4TX5rgZUmbhEucWn0KTBMeDEPXg99YKtTA==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "@lezer/xml": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
-      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
-      "requires": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
       }
     },
     "@next/env": {
@@ -6850,6 +6417,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/codemirror": {
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
+      "dev": true,
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -6881,8 +6457,7 @@
     "@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "peer": true
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -6973,6 +6548,15 @@
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/tern": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
       }
     },
     "@types/unist": {
@@ -7089,43 +6673,6 @@
       "requires": {
         "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
-      }
-    },
-    "@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.15.1.tgz",
-      "integrity": "sha512-LP2LHyPQm6ikYyXxT+1Odz+kiVLzzUmHSwBapSF4JgUE4b5QaBA7KCiTfwIWJPC528QVP2qWk1DEBNstPMiUdg==",
-      "requires": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
-    },
-    "@uiw/codemirror-themes": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.15.1.tgz",
-      "integrity": "sha512-+3NKdmptuZTGE56LQ3j8daOAKer2STEDklkJS9AGHAGoN1o7IdA+s2Pbp3hf5oGxukNb29UA+gskfb5grszWMg==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
-    },
-    "@uiw/react-codemirror": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.15.1.tgz",
-      "integrity": "sha512-lgtMFS8D2t9ri3ug3kgWoLPPdxDkqkYBWm3dVU9Z7GRs4R1iN2WSr2Z/biQ8KbdyLygRT5isi1k3Ud9ZY6j+YA==",
-      "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.15.1",
-        "codemirror": "^6.0.0"
       }
     },
     "@webassemblyjs/ast": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,15 @@
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.0.5",
-    "@codemirror/language-data": "^6.1.0",
+    "@codemirror/language": "^6.3.1",
+    "@codemirror/state": "^6.1.4",
+    "@codemirror/view": "^6.6.0",
     "@lezer/highlight": "^1.1.2",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
-    "@uiw/codemirror-themes": "^4.15.1",
-    "@uiw/react-codemirror": "^4.15.1",
     "axios": "^1.1.3",
+    "codemirror": "^6.0.1",
     "dotenv": "^16.0.3",
     "dotenv-webpack": "^8.0.1",
     "eslint": "8.27.0",
@@ -35,6 +36,7 @@
     "unified": "^10.1.2"
   },
   "devDependencies": {
+    "@types/codemirror": "^5.60.5",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -3,13 +3,15 @@ import axios from 'axios';
 interface Api {
   url: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  header?: Record<string, string>;
   data?: unknown;
   params?: unknown;
 }
 
-const api = async ({ url, method, data, params }: Api) => {
+const api = async ({ url, method, header, data, params }: Api) => {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    ...header,
   };
 
   const response = await axios({


### PR DESCRIPTION
## 개요

에디터에 복사한 이미지를 붙여넣었을 때 서버에 업로드 후 첨부되는 동작 추가

## 변경 사항

- 에디터 라이브러리 수정 (`@uiw/react-codemirror`에서 `codemirror`로 변경)
- useCodeMirror 훅 추가
- 이미지 붙여넣기 관련 `onPaste` 이벤트 핸들러 추가

## 참고 사항

- 이미지를 formData에 넣어서 서버에 요청을 보낼 때 기존 헤더처럼 `Content-Type: application/json`으로 보내는 것이 아니라 `Content-Type: multipart/form-data`으로 보내야하기 때문에 관련된 api 유틸리티 함수를 수정했습니다.
- 기존 `@uiw/react-codemirror` 에디터에서 에디터의 상태(현재 커서의 위치 등을 포함하는 상태)가 변경되었을 때(= 에디터의 내용이 수정되었을 때), 에디터의 갱신된 상태를 받아올 수 없는 이슈가 있었습니다.
  - 이미지를 붙여넣기 했을 때 서버에 이미지를 formData에 넣어서 요청을 보낸 후 nCloud Object Storage에 저장된 URL을 응답받게 됩니다. 
  -  응답받은 URL을 현재 에디터 커서 위치에 첨부해야하는데 기존 라이브러리에서는 갱신된 커서의 위치를 받아올 수 없기 때문에 에디터의 전면 수정이 필요했습니다.
  - 이러한 이유로 `@uiw/react-codemirror`를 사용하지 않고, `codemirror` 라이브러리 자체를 적용하도록 코드를 변경했습니다.
  - 변경 과정에서 참고한 [문서](https://www.codiga.io/blog/implement-codemirror-6-in-react)입니다.
- 이미지를 파일 시스템에서 복사한 후(= 사용자가 자신의 이미지 파일을 복사한 후), 붙여넣기 했을 때 onPaste 이벤트가 실행됩니다. 이때 클립보드에 들어있는 이미지 파일을 읽어와야하는데, 파일은 두 개 이상을 복사할 수 있기 때문에 clipboardData의 items(클립보드 데이터)가 리스트 형태로 되어있습니다.
  - 이 과정에서 items를 iterator를 통해서 순회해야하는데 이 과정에서 `--downlevelIteration` 이슈가 있었습니다. 오류를 해결하지 않고 넘어가면 빌드 과정에서 에러가 발생하기 때문에 프론트엔드 타입스크립트 컴파일 타겟을 es5에서 es6로 변경했습니다.
  - 이 과정에서 참고한 [문서](https://mariusschulz.com/blog/downlevel-iteration-for-es3-es5-in-typescript)입니다.
- GitHub이나 Velog처럼 이미지를 복사했을 때 로딩 표시가 나타나는 부분은 구현되지 않았습니다. 추후에 필요하다면 수정하겠습니다.

## 스크린샷

![화면 기록 2022-11-28 03 18 01](https://user-images.githubusercontent.com/26927792/204152858-bec4a611-3fe9-47bd-ba88-770006fc02e9.gif)

## 관련 이슈

- #64 
