### PR TITLE
toast 메세지 추가, 로그인,회원가입 모달 수정

### DIFF
--- a/frontend/apis/authApi.ts
+++ b/frontend/apis/authApi.ts
@@ -1,0 +1,26 @@
+import api from '@utils/api';
+
+interface LocalLoginApi {
+  username: string;
+  password: number;
+}
+
+interface CreateUserApi extends LocalLoginApi {
+  nickname: string;
+}
+
+export const createUserApi = async (data: CreateUserApi) => {
+  const url = `/api/auth/signup`;
+
+  const response = await api({ url, method: 'POST', data });
+
+  return response.data;
+};
+
+export const localLoginApi = async (data: LocalLoginApi) => {
+  const url = `/api/auth/signin/local`;
+
+  const response = await api({ url, method: 'POST', data });
+
+  return response.data;
+};

--- a/frontend/components/SignInModal/index.tsx
+++ b/frontend/components/SignInModal/index.tsx
@@ -1,24 +1,34 @@
 import Image from 'next/image';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import axios from 'axios';
-
+import { localLoginApi } from '@apis/authApi';
 import GithubIcon from '@assets/ico_github.svg';
 import LabeledInput from '@components/common/LabeledInput';
 import Button from '@components/common/Modal/ModalButton';
+import useFetch from '@hooks/useFetch';
 
 import { SignInModalWrapper, SignUpContainer, SignUpButton } from './styled';
 
+interface SignInModalProps {
+  handleGoToSignUpBtnClicked: () => void;
+  handleModalClose: () => void;
+}
+
 export default function SignInModal({
   handleGoToSignUpBtnClicked,
-}: {
-  handleGoToSignUpBtnClicked: () => void;
-}) {
+  handleModalClose,
+}: SignInModalProps) {
   const [info, setInfo] = useState({
     username: '',
     password: '',
   });
+  const { data: localLoginData, execute: localLogin } = useFetch(localLoginApi);
+
+  useEffect(() => {
+    if (!localLoginData) return;
+    handleModalClose();
+  }, [localLoginData]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInfo({
@@ -34,21 +44,7 @@ export default function SignInModal({
   };
 
   const handleSignInBtnOnClick = () => {
-    axios
-      .post(
-        `${process.env.NEXT_PUBLIC_SERVER_URL}/api/auth/signin/local`,
-        {
-          username: info.username,
-          password: info.password,
-        },
-        {
-          withCredentials: true,
-        }
-      )
-      .then((res) =>
-        // 응답으로 받아온 로그인 정보를 이용해 전역 상태 관리!!
-        console.log(res)
-      );
+    localLogin({ username: info.username, password: info.password });
   };
 
   return (

--- a/frontend/components/SignUpModal/index.tsx
+++ b/frontend/components/SignUpModal/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import { createUserApi } from '@apis/authApi';
 import LabeledInput from '@components/common/LabeledInput';
@@ -24,6 +25,16 @@ function SignUpModal({ handleModalClose }: SignUpModalProps) {
   useEffect(() => {
     if (createUserData === undefined) return;
     handleModalClose();
+    toast.success('Knoticle 가입을 축하합니다!', {
+      position: 'top-right',
+      autoClose: 3000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+      theme: 'light',
+    });
   }, [createUserData]);
 
   const checkUsernameValid = (username: string) => {

--- a/frontend/components/SignUpModal/index.tsx
+++ b/frontend/components/SignUpModal/index.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { createUserApi } from '@apis/authApi';
 import LabeledInput from '@components/common/LabeledInput';
 import Button from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
+import { toastSuccess } from '@utils/toast';
 
 import { SignUpModalWrapper, SignUpModalErrorMessage } from './styled';
 
@@ -25,16 +25,7 @@ function SignUpModal({ handleModalClose }: SignUpModalProps) {
   useEffect(() => {
     if (createUserData === undefined) return;
     handleModalClose();
-    toast.success('Knoticle 가입을 축하합니다!', {
-      position: 'top-right',
-      autoClose: 3000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-      theme: 'light',
-    });
+    toastSuccess('Knoticle 가입을 축하합니다!');
   }, [createUserData]);
 
   const checkUsernameValid = (username: string) => {

--- a/frontend/components/SignUpModal/index.tsx
+++ b/frontend/components/SignUpModal/index.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import axios from 'axios';
-
+import { createUserApi } from '@apis/authApi';
 import LabeledInput from '@components/common/LabeledInput';
 import Button from '@components/common/Modal/ModalButton';
+import useFetch from '@hooks/useFetch';
 
 import { SignUpModalWrapper, SignUpModalErrorMessage } from './styled';
 
@@ -19,6 +19,12 @@ function SignUpModal({ handleModalClose }: SignUpModalProps) {
     password: '',
     nickname: '',
   });
+  const { data: createUserData, execute: createUser } = useFetch(createUserApi);
+
+  useEffect(() => {
+    if (createUserData === undefined) return;
+    handleModalClose();
+  }, [createUserData]);
 
   const checkUsernameValid = (username: string) => {
     if (/[^a-zA-Z0-9]/.test(username) || username.length > 10) {
@@ -44,14 +50,7 @@ function SignUpModal({ handleModalClose }: SignUpModalProps) {
   };
 
   const handleSignUpBtnClick = () => {
-    axios
-      .post(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/auth/signup`, info)
-      .then(() => {
-        handleModalClose();
-      })
-      .catch((err) => {
-        setErrorMessage(err.response.data.message);
-      });
+    createUser(info);
   };
 
   return (

--- a/frontend/components/common/GNB/index.tsx
+++ b/frontend/components/common/GNB/index.tsx
@@ -50,7 +50,10 @@ export default function GNB() {
           </Modal>
         )) || (
           <Modal title="Knoticle 시작하기" handleModalClose={handleModalClose}>
-            <SignInModal handleGoToSignUpBtnClicked={handleGoToSignUpBtnClicked} />
+            <SignInModal
+              handleGoToSignUpBtnClicked={handleGoToSignUpBtnClicked}
+              handleModalClose={handleModalClose}
+            />
           </Modal>
         ))}
     </GNBbar>

--- a/frontend/hooks/useFetch.ts
+++ b/frontend/hooks/useFetch.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useCallback, useState } from 'react';
-import { toast } from 'react-toastify';
+
+import { toastError } from '@utils/toast';
 
 const useFetch = <T>(api: (...args: any[]) => Promise<T>) => {
   const [data, setData] = useState<T>();
@@ -11,16 +12,7 @@ const useFetch = <T>(api: (...args: any[]) => Promise<T>) => {
     } catch (error: any) {
       const { message } = error.response.data;
 
-      toast.error(message, {
-        position: 'top-right',
-        autoClose: 3000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-        theme: 'light',
-      });
+      toastError(message);
     }
   }, []);
 

--- a/frontend/hooks/useFetch.ts
+++ b/frontend/hooks/useFetch.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useCallback, useState } from 'react';
+import { toast } from 'react-toastify';
 
 const useFetch = <T>(api: (...args: any[]) => Promise<T>) => {
   const [data, setData] = useState<T>();
@@ -10,7 +11,16 @@ const useFetch = <T>(api: (...args: any[]) => Promise<T>) => {
     } catch (error: any) {
       const { message } = error.response.data;
 
-      console.log(message);
+      toast.error(message, {
+        position: 'top-right',
+        autoClose: 3000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: 'light',
+      });
     }
   }, []);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "next": "13.0.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-toastify": "^9.1.1",
         "recoil": "^0.7.6",
         "rehype-stringify": "^9.0.3",
         "remark-parse": "^10.0.1",
@@ -1796,6 +1797,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/codemirror": {
       "version": "6.0.1",
@@ -4701,6 +4710,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/recoil": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
@@ -7091,6 +7112,11 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "codemirror": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
@@ -9051,6 +9077,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
     },
     "recoil": {
       "version": "0.7.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "next": "13.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",
     "rehype-stringify": "^9.0.3",
     "remark-parse": "^10.0.1",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,5 +1,8 @@
 import type { AppProps } from 'next/app';
 
+import 'react-toastify/dist/ReactToastify.css';
+import { ToastContainer } from 'react-toastify';
+
 import { RecoilRoot } from 'recoil';
 
 import GlobalStyle from '@styles/GlobalStyle';
@@ -9,6 +12,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <RecoilRoot>
       <GlobalStyle />
       <Component {...pageProps} />
+      <ToastContainer limit={3} />
     </RecoilRoot>
   );
 }

--- a/frontend/utils/toast.ts
+++ b/frontend/utils/toast.ts
@@ -1,0 +1,27 @@
+import { toast } from 'react-toastify';
+
+export const toastError = (message: string) => {
+  toast.error(message, {
+    position: 'top-right',
+    autoClose: 3000,
+    hideProgressBar: false,
+    closeOnClick: true,
+    pauseOnHover: true,
+    draggable: true,
+    progress: undefined,
+    theme: 'light',
+  });
+};
+
+export const toastSuccess = (message: string) => {
+  toast.success(message, {
+    position: 'top-right',
+    autoClose: 3000,
+    hideProgressBar: false,
+    closeOnClick: true,
+    pauseOnHover: true,
+    draggable: true,
+    progress: undefined,
+    theme: 'light',
+  });
+};


### PR DESCRIPTION
## 개요

toast 메세지 추가

## 변경 사항

- toast 메세지 추가
- 로그인, 회원가입 모달 변경 (axios -> useFetch)

## 참고 사항

- toast 메세지 추가했습니다.
- 공식 사이트 링크 : https://fkhadra.github.io/react-toastify/introduction

- 로그인, 회원가입 테스트 중 모달이 닫히지 않는 부분 확인되어 수정했습니다.
- axios -> useFetch로 변경했습니다.

- 현재 3초 후 닫히도록 구현했는데 시간이 적절한지 확인부탁드립니다.

## 스크린샷

- 로그인

https://user-images.githubusercontent.com/87806611/204236453-c7294dae-fadb-4ff6-b1e1-6507be123051.mov


- 회원가입

https://user-images.githubusercontent.com/87806611/204236474-f07131ce-5ce8-4034-ba33-0b22be41c04d.mov

- 회원가입 성공

https://user-images.githubusercontent.com/87806611/204244717-d3fd6184-bc41-4d90-9c70-98f2029c49ac.mov



## 관련 이슈

관련 이슈 없음
