### PR TITLE
서버 책 검색 결과 반환 기능 구현 

### DIFF
--- a/backend/src/apis/books/books.controller.ts
+++ b/backend/src/apis/books/books.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 
 import booksService from '@apis/books/books.service';
 
-import { FindBooks } from './books.interface';
+import { FindBooks, SearchBooks } from './books.interface';
 
 const getBook = async (req: Request, res: Response) => {
   const { bookId } = req.params;
@@ -28,7 +28,16 @@ const getBooks = async (req: Request, res: Response) => {
   res.status(200).send(books);
 };
 
+const getSearchedBooks = async (req: Request, res: Response) => {
+  const { query, page, userId } = req.query as unknown as SearchBooks;
+
+  const books = await booksService.searchBooks({ query, userId, page });
+
+  res.status(200).send(books);
+};
+
 export default {
   getBook,
   getBooks,
+  getSearchedBooks,
 };

--- a/backend/src/apis/books/books.interface.ts
+++ b/backend/src/apis/books/books.interface.ts
@@ -4,3 +4,9 @@ export interface FindBooks {
   userId?: number;
   editor?: string;
 }
+
+export interface SearchBooks {
+  query: string;
+  page: number;
+  userId?: number;
+}

--- a/backend/src/apis/books/books.service.ts
+++ b/backend/src/apis/books/books.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@config/orm.config';
 
-import { FindBooks } from './books.interface';
+import { FindBooks, SearchBooks } from './books.interface';
 
 const findBook = async (bookId: number, userId: number) => {
   const book = await prisma.book.findFirst({
@@ -96,7 +96,56 @@ const findBooks = async ({ order, take, userId, editor }: FindBooks) => {
   return books;
 };
 
+const searchBooks = async ({ query, userId, page }: SearchBooks) => {
+  const skip = (page - 1) * 10;
+
+  const books = await prisma.book.findMany({
+    select: {
+      id: true,
+      title: true,
+      thumbnail_image: true,
+      created_at: true,
+      user: {
+        select: {
+          nickname: true,
+        },
+      },
+      scraps: {
+        select: {
+          order: true,
+          article: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
+        },
+      },
+      bookmarks: {
+        where: {
+          user_id: userId,
+        },
+      },
+      _count: {
+        select: { bookmarks: true },
+      },
+    },
+    where: {
+      deleted_at: null,
+      user_id: userId ? Number(userId) : undefined,
+      title: {
+        search: `${query}*`,
+      },
+    },
+    skip,
+    take: 10,
+  });
+
+  return books;
+};
+
 export default {
   findBook,
   findBooks,
+  searchBooks,
 };

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -25,7 +25,7 @@ router.delete('/articles/:articleId', catchAsync(articlesController.deleteArticl
 
 router.post('/image', multer().single('image'), catchAsync(imagesController.createImage));
 
-router.get('/books/search');
+router.get('/books/search', catchAsync(booksController.getSearchedBooks));
 router.get('/books/:bookId', decoder, catchAsync(booksController.getBook));
 router.get('/books', decoder, catchAsync(booksController.getBooks));
 


### PR DESCRIPTION
## 개요

책 검색 결과 요청 시 서버에서 검색 결과를 반환해주는 api를 개발하였습니다.

## 변경 사항

- books.controller.ts에 getSearchedBooks 함수 추가
- books.service.ts에 searchBooks 함수 추가
- books.interface.ts에 검색 요청 쿼리 파라미터의 타입인 SearchBooks 추가

## 참고 사항

- `search: `${query}*``는 query가 'abc'일 때 단어 'abc'를 갖고 있거나, 'abcdef' 처럼 'abc'로 시작하는 단어를 갖고 있는 아이템을 찾습니다. Mysql 상에서 'defabc' 처럼 query 앞에 문자가 붙은 단어를 찾아주는 기능은 full text index에서는 지원하지 않는 것 같습니다. 

## 관련 이슈

- #120 
