### PR TITLE
서재페이지 프로필 구현

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,8 +15,9 @@ model User {
   username String @db.VarChar(20)
   password String @db.VarChar(100)
   nickname String @db.VarChar(20) @unique
-  provider String @db.VarChar(20)
+  description String @db.VarChar(100)
   profile_image String @db.VarChar(255)
+  provider String @db.VarChar(20)
   created_at DateTime @default(now())
   deleted_at DateTime?
   books Book[]

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   password String @db.VarChar(100)
   nickname String @db.VarChar(20) @unique
   description String @db.VarChar(100)
-  profile_image String @db.VarChar(255)
+  profile_image String @db.VarChar(255) @default("https://kr.object.ncloudstorage.com/j027/522da4f3-c9d7-403d-a98f-2b09cabefc47.png")
   provider String @db.VarChar(20)
   created_at DateTime @default(now())
   deleted_at DateTime?
@@ -27,8 +27,8 @@ model User {
 }
 
 model Book {
-  id  Int @id @default(autoincrement())
-  thumbnail_image String @db.VarChar(255)
+  id  Int @id @default(autoincrement()) 
+  thumbnail_image String @db.VarChar(255) @default("https://kr.object.ncloudstorage.com/j027/3947d647-f26e-43cc-9834-82d59703cd9c.png")
   title String @db.VarChar(50)
   created_at DateTime @default(now())
   deleted_at DateTime?

--- a/backend/src/apis/articles/articles.controller.ts
+++ b/backend/src/apis/articles/articles.controller.ts
@@ -24,6 +24,7 @@ const publish = async (req: Request, res: Response) => {
 
 const getArticle = async (req: Request, res: Response) => {
   const articleId = Number(req.params.articleId);
+
   const articleData = await articlesService.getArticleData(articleId);
 
   res.status(200).send(articleData);

--- a/backend/src/apis/auth/auth.service.ts
+++ b/backend/src/apis/auth/auth.service.ts
@@ -4,14 +4,6 @@ import { hash, compare } from 'bcrypt';
 import { prisma } from '@config/orm.config';
 import { ResourceConflict, Message, Unauthorized } from '@errors';
 
-const DEFAULT_USER_PROFILE_IMAGE =
-  'https://kr.object.ncloudstorage.com/j027/522da4f3-c9d7-403d-a98f-2b09cabefc47.png';
-
-/* 유저 기본 이미지 링크 - 깃헙 기본 이미지
-const DEFAULT_USER_PROFILE_IMAGE =
-'https://kr.object.ncloudstorage.com/j027/c170bccf-4f0a-4d1b-9e65-de2885e1a5ee.png';
-*/
-
 const getSignedUser = async (username: string, password: string) => {
   const user = await prisma.user.findFirst({
     where: {
@@ -79,7 +71,6 @@ const signUpGithubUser = async (username: string, provider_id: string) => {
       nickname,
       provider: 'github',
       password: '',
-      profile_image: DEFAULT_USER_PROFILE_IMAGE,
       description: `안녕하세요 ${nickname}입니다.`,
     },
   });
@@ -137,7 +128,6 @@ const signUpLocalUser = async (username: string, password: string, nickname: str
       nickname,
       provider: 'local',
       password: encryptedPassword,
-      profile_image: DEFAULT_USER_PROFILE_IMAGE,
       description: `안녕하세요 ${nickname}입니다.`,
     },
   });

--- a/backend/src/apis/auth/auth.service.ts
+++ b/backend/src/apis/auth/auth.service.ts
@@ -4,6 +4,14 @@ import { hash, compare } from 'bcrypt';
 import { prisma } from '@config/orm.config';
 import { ResourceConflict, Message, Unauthorized } from '@errors';
 
+const DEFAULT_USER_PROFILE_IMAGE =
+  'https://kr.object.ncloudstorage.com/j027/522da4f3-c9d7-403d-a98f-2b09cabefc47.png';
+
+/* 유저 기본 이미지 링크 - 깃헙 기본 이미지
+const DEFAULT_USER_PROFILE_IMAGE =
+'https://kr.object.ncloudstorage.com/j027/c170bccf-4f0a-4d1b-9e65-de2885e1a5ee.png';
+*/
+
 const getSignedUser = async (username: string, password: string) => {
   const user = await prisma.user.findFirst({
     where: {
@@ -71,7 +79,7 @@ const signUpGithubUser = async (username: string, provider_id: string) => {
       nickname,
       provider: 'github',
       password: '',
-      profile_image: '',
+      profile_image: DEFAULT_USER_PROFILE_IMAGE,
       description: `안녕하세요 ${nickname}입니다.`,
     },
   });
@@ -129,7 +137,7 @@ const signUpLocalUser = async (username: string, password: string, nickname: str
       nickname,
       provider: 'local',
       password: encryptedPassword,
-      profile_image: '',
+      profile_image: DEFAULT_USER_PROFILE_IMAGE,
       description: `안녕하세요 ${nickname}입니다.`,
     },
   });

--- a/backend/src/apis/auth/auth.service.ts
+++ b/backend/src/apis/auth/auth.service.ts
@@ -72,6 +72,7 @@ const signUpGithubUser = async (username: string, provider_id: string) => {
       provider: 'github',
       password: '',
       profile_image: '',
+      description: `안녕하세요 ${nickname}입니다.`,
     },
   });
 
@@ -129,6 +130,7 @@ const signUpLocalUser = async (username: string, password: string, nickname: str
       provider: 'local',
       password: encryptedPassword,
       profile_image: '',
+      description: `안녕하세요 ${nickname}입니다.`,
     },
   });
 };

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -8,6 +8,7 @@ import bookmarksController from '@apis/bookmarks/bookmarks.controller';
 import booksController from '@apis/books/books.controller';
 import imagesController from '@apis/images/images.controller';
 import scrapsController from '@apis/scraps/scraps.controller';
+import usersController from '@apis/users/users.controller';
 import decoder from '@middlewares/tokenDecoder';
 import guard from '@middlewares/tokenValidator';
 import { catchAsync } from '@utils/catch-async';
@@ -36,5 +37,7 @@ router.post('/bookmarks', catchAsync(guard), catchAsync(bookmarksController.crea
 router.delete('/bookmarks/:bookmarkId', catchAsync(bookmarksController.deleteBookmark));
 
 router.post('/scraps', catchAsync(scrapsController.createScrap));
+
+router.get('/users', catchAsync(usersController.getUserProfile));
 
 export default router;

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -39,5 +39,6 @@ router.delete('/bookmarks/:bookmarkId', catchAsync(bookmarksController.deleteBoo
 router.post('/scraps', catchAsync(scrapsController.createScrap));
 
 router.get('/users', catchAsync(usersController.getUserProfile));
+router.patch('/users/:userId', catchAsync(usersController.editUserProfile));
 
 export default router;

--- a/backend/src/apis/users/users.controller.ts
+++ b/backend/src/apis/users/users.controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+
+import usersService from 'apis/users/users.service';
+
+const getUserProfile = async (req: Request, res: Response) => {
+  const userNickname = req.query.nickname as string;
+
+  const userProfile = await usersService.findUserProfile(userNickname);
+
+  res.status(200).send(userProfile);
+};
+
+export default {
+  getUserProfile,
+};

--- a/backend/src/apis/users/users.controller.ts
+++ b/backend/src/apis/users/users.controller.ts
@@ -14,11 +14,9 @@ const getUserProfile = async (req: Request, res: Response) => {
 const editUserProfile = async (req: Request, res: Response) => {
   // const userId = Number(req.params.userId);
 
-  console.log('editUserProfile', req.params, req.body);
+  const userProfile = await usersService.updateUserProfile(req.body);
 
-  await usersService.updateUserProfile(req.body);
-
-  res.status(204).send();
+  res.status(200).send(userProfile);
 };
 
 export default {

--- a/backend/src/apis/users/users.controller.ts
+++ b/backend/src/apis/users/users.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import usersService from 'apis/users/users.service';
+import usersService from '@apis/users/users.service';
 
 const getUserProfile = async (req: Request, res: Response) => {
   const userNickname = req.query.nickname as string;
@@ -10,6 +10,18 @@ const getUserProfile = async (req: Request, res: Response) => {
   res.status(200).send(userProfile);
 };
 
+// PATCH인데 id가 req.body에 담겨서 오다보니 params를 확인할 일이 없는데...
+const editUserProfile = async (req: Request, res: Response) => {
+  // const userId = Number(req.params.userId);
+
+  console.log('editUserProfile', req.params, req.body);
+
+  await usersService.updateUserProfile(req.body);
+
+  res.status(204).send();
+};
+
 export default {
   getUserProfile,
+  editUserProfile,
 };

--- a/backend/src/apis/users/users.interface.ts
+++ b/backend/src/apis/users/users.interface.ts
@@ -1,0 +1,6 @@
+export interface UpdateUserProfile {
+  id: number;
+  nickname: string;
+  profile_image: string;
+  description: string;
+}

--- a/backend/src/apis/users/users.service.ts
+++ b/backend/src/apis/users/users.service.ts
@@ -51,7 +51,20 @@ const getUserByNickname = async (nickname: string) => {
   return user;
 };
 
+const getUserById = async (id: number) => {
+  const user = await prisma.user.findFirst({
+    where: {
+      id,
+    },
+  });
+
+  if (!user) throw new NotFound(Message.USER_NOTFOUND);
+
+  return user;
+};
+
 export default {
   findUserProfile,
   updateUserProfile,
+  getUserById,
 };

--- a/backend/src/apis/users/users.service.ts
+++ b/backend/src/apis/users/users.service.ts
@@ -27,7 +27,7 @@ const updateUserProfile = async (dto: UpdateUserProfile) => {
   const user = await getUserByNickname(nickname);
   if (user && user.id !== id) throw new ResourceConflict(Message.AUTH_NICKNAME_OVERLAP);
 
-  await prisma.user.update({
+  const userProfile = await prisma.user.update({
     where: {
       id,
     },
@@ -37,6 +37,8 @@ const updateUserProfile = async (dto: UpdateUserProfile) => {
       description,
     },
   });
+
+  return userProfile;
 };
 
 const getUserByNickname = async (nickname: string) => {

--- a/backend/src/apis/users/users.service.ts
+++ b/backend/src/apis/users/users.service.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@config/orm.config';
-import { Message, NotFound } from '@errors';
+import { Message, NotFound, ResourceConflict } from '@errors';
+
+import { UpdateUserProfile } from './users.interface';
 
 const findUserProfile = async (nickname: string) => {
   const userProfile = await prisma.user.findFirst({
@@ -19,6 +21,36 @@ const findUserProfile = async (nickname: string) => {
   return userProfile;
 };
 
+const updateUserProfile = async (dto: UpdateUserProfile) => {
+  const { id, nickname, profile_image, description } = dto;
+
+  if (!(await checkNicknameUnique(nickname)))
+    throw new ResourceConflict(Message.AUTH_NICKNAME_OVERLAP);
+
+  await prisma.user.update({
+    where: {
+      id,
+    },
+    data: {
+      profile_image,
+      nickname,
+      description,
+    },
+  });
+};
+
+// authService에서 중복되서 사용했는데 어떻게 하면 좋을지... 같은 레이어층 가져와서 써도 될까요...?
+const checkNicknameUnique = async (nickname: string) => {
+  const user = await prisma.user.findFirst({
+    where: {
+      nickname,
+    },
+  });
+
+  return !user ? true : false;
+};
+
 export default {
   findUserProfile,
+  updateUserProfile,
 };

--- a/backend/src/apis/users/users.service.ts
+++ b/backend/src/apis/users/users.service.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@config/orm.config';
+import { Message, NotFound } from '@errors';
+
+const findUserProfile = async (nickname: string) => {
+  const userProfile = await prisma.user.findFirst({
+    where: {
+      nickname,
+    },
+    select: {
+      id: true,
+      profile_image: true,
+      nickname: true,
+      description: true,
+    },
+  });
+
+  if (!userProfile) throw new NotFound(Message.USER_NOTFOUND);
+
+  return userProfile;
+};
+
+export default {
+  findUserProfile,
+};

--- a/backend/src/apis/users/users.service.ts
+++ b/backend/src/apis/users/users.service.ts
@@ -24,8 +24,8 @@ const findUserProfile = async (nickname: string) => {
 const updateUserProfile = async (dto: UpdateUserProfile) => {
   const { id, nickname, profile_image, description } = dto;
 
-  if (!(await checkNicknameUnique(nickname)))
-    throw new ResourceConflict(Message.AUTH_NICKNAME_OVERLAP);
+  const user = await getUserByNickname(nickname);
+  if (user && user.id !== id) throw new ResourceConflict(Message.AUTH_NICKNAME_OVERLAP);
 
   await prisma.user.update({
     where: {
@@ -39,15 +39,14 @@ const updateUserProfile = async (dto: UpdateUserProfile) => {
   });
 };
 
-// authService에서 중복되서 사용했는데 어떻게 하면 좋을지... 같은 레이어층 가져와서 써도 될까요...?
-const checkNicknameUnique = async (nickname: string) => {
+const getUserByNickname = async (nickname: string) => {
   const user = await prisma.user.findFirst({
     where: {
       nickname,
     },
   });
 
-  return !user ? true : false;
+  return user;
 };
 
 export default {

--- a/backend/src/middlewares/tokenValidator.ts
+++ b/backend/src/middlewares/tokenValidator.ts
@@ -5,23 +5,23 @@ import token from '@utils/token';
 
 const guard = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { id, nickname } = token.verifyJWT(req.cookies.access_token);
-    res.locals.user = { id, nickname };
+    const { id } = token.verifyJWT(req.cookies.access_token);
+    res.locals.user = { id };
     next();
   } catch (err) {
     if (err.message === 'jwt expired') {
-      const { id, nickname } = token.decodeJWT(req.cookies.access_token);
+      const { id } = token.decodeJWT(req.cookies.access_token);
 
       await token.checkRefreshTokenValid(req.cookies.refresh_token);
 
-      const { accessToken, refreshToken } = token.getTokens(id, nickname);
+      const { accessToken, refreshToken } = token.getTokens(id);
 
       await token.saveRefreshToken(id, refreshToken);
 
       res.cookie('access_token', accessToken, { httpOnly: true });
       res.cookie('refresh_token', refreshToken, { httpOnly: true });
 
-      res.locals.user = { id, nickname };
+      res.locals.user = { id };
 
       next();
     } else throw new Unauthorized(Message.TOKEN_MALFORMED);

--- a/backend/src/utils/token.ts
+++ b/backend/src/utils/token.ts
@@ -3,7 +3,7 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 import { prisma } from '@config/orm.config';
 import { Message, Unauthorized } from '@errors';
 
-const generateJWT = (expiresIn: '3h' | '7d', payload: { id?: number; nickname?: string } = {}) => {
+const generateJWT = (expiresIn: '3h' | '7d', payload: { id?: number } = {}) => {
   return jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn });
 };
 
@@ -15,8 +15,8 @@ const decodeJWT = (token: string) => {
   return jwt.decode(token) as JwtPayload;
 };
 
-const getTokens = (userId: number, nickname: string) => {
-  const accessToken = generateJWT('3h', { id: userId, nickname });
+const getTokens = (userId: number) => {
+  const accessToken = generateJWT('3h', { id: userId });
   const refreshToken = generateJWT('7d');
 
   return {

--- a/frontend/apis/userApi.ts
+++ b/frontend/apis/userApi.ts
@@ -1,4 +1,3 @@
-import { IUser } from '@interfaces';
 import api from '@utils/api';
 
 export const getUserProfileApi = async (nickname: string) => {
@@ -10,11 +9,14 @@ export const getUserProfileApi = async (nickname: string) => {
 };
 
 interface UpdateUserProfileApi {
-  userProfile: IUser;
+  id: number;
+  nickname?: string;
+  description?: string;
+  profile_image?: string;
 }
 
 export const updateUserProfileApi = async (data: UpdateUserProfileApi) => {
-  const url = `/api/users/${data.userProfile.id}`;
+  const url = `/api/users/${data.id}`;
 
   const response = await api({ url, method: 'PATCH', data });
 

--- a/frontend/apis/userApi.ts
+++ b/frontend/apis/userApi.ts
@@ -1,0 +1,10 @@
+import api from '@utils/api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getUserProfileApi = async (nickname: string) => {
+  const url = `/api/users?nickname=${nickname}`;
+
+  const response = await api({ url, method: 'GET' });
+
+  return response.data;
+};

--- a/frontend/apis/userApi.ts
+++ b/frontend/apis/userApi.ts
@@ -1,10 +1,22 @@
+import { IUser } from '@interfaces';
 import api from '@utils/api';
 
-// eslint-disable-next-line import/prefer-default-export
 export const getUserProfileApi = async (nickname: string) => {
   const url = `/api/users?nickname=${nickname}`;
 
   const response = await api({ url, method: 'GET' });
+
+  return response.data;
+};
+
+interface UpdateUserProfileApi {
+  userProfile: IUser;
+}
+
+export const updateUserProfileApi = async (data: UpdateUserProfileApi) => {
+  const url = `/api/users/${data.userProfile.id}`;
+
+  const response = await api({ url, method: 'PATCH', data });
 
   return response.data;
 };

--- a/frontend/components/common/GNB/index.tsx
+++ b/frontend/components/common/GNB/index.tsx
@@ -41,7 +41,7 @@ export default function GNB() {
         </Link>
 
         {signInStatus.id !== 0 ? (
-          <Link href={`/study/${signInStatus.id}`}>
+          <Link href={`/study/${signInStatus.nickname}`}>
             <Icon src={PersonIcon} alt="Person Icon" />
           </Link>
         ) : (

--- a/frontend/components/study/EditUserProfile/index.tsx
+++ b/frontend/components/study/EditUserProfile/index.tsx
@@ -18,6 +18,7 @@ import {
   UserProfileWrapper,
   UserThumbnail,
   EditThumbnailIcon,
+  UserThumbnailGroup,
 } from './styled';
 
 interface EditUserProfileProps {
@@ -73,7 +74,7 @@ export default function EditUserProfile({
 
   return (
     <UserProfileWrapper>
-      <div>
+      <UserThumbnailGroup>
         <UserThumbnail src={curUserProfile.profile_image} alt="User1" width={200} height={200} />
         <EditThumbnailIcon onClick={handleEditThumbnailClick}>
           <Image src={Edit} alt="profile_edit" width={20} />
@@ -85,7 +86,7 @@ export default function EditUserProfile({
             onChange={handleFileUpload}
           />
         </EditThumbnailIcon>
-      </div>
+      </UserThumbnailGroup>
 
       <UserDetailGroup>
         <EditUsername defaultValue={curUserProfile.nickname} onChange={onNicknameChange} />

--- a/frontend/components/study/EditUserProfile/index.tsx
+++ b/frontend/components/study/EditUserProfile/index.tsx
@@ -1,0 +1,76 @@
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+
+import { useEffect } from 'react';
+
+import { useRecoilState } from 'recoil';
+
+import Edit from '@assets/ico_edit.svg';
+import signInStatusState from '@atoms/signInStatus';
+import useFetch from '@hooks/useFetch';
+import useInput from '@hooks/useInput';
+import { IUser } from '@interfaces';
+import { TextLinkMedium } from '@styles/common';
+
+import {
+  ButtonGroup,
+  EditUsername,
+  ProfileEditButton,
+  EditUserDescription,
+  UserDetailGroup,
+  UserProfileWrapper,
+  UserThumbnail,
+} from './styled';
+
+interface EditUserProfileProps {
+  userProfile: IUser;
+  curUserProfile: IUser;
+  handleEditFinishBtnClick: () => void;
+  setCurUserProfile: (userProfile: IUser) => void;
+}
+
+export default function EditUserProfile({
+  userProfile,
+  curUserProfile,
+  handleEditFinishBtnClick,
+  setCurUserProfile,
+}: EditUserProfileProps) {
+  const router = useRouter();
+  const { value: nicknameValue, onChange: onNicknameChange } = useInput(userProfile.nickname);
+  const { value: descriptionValue, onChange: onDescriptionChange } = useInput(
+    userProfile.description
+  );
+
+  useEffect(() => {
+    setCurUserProfile({
+      ...curUserProfile,
+      nickname: nicknameValue,
+      description: descriptionValue,
+    });
+  }, [nicknameValue, descriptionValue]);
+
+  return (
+    <UserProfileWrapper>
+      <UserThumbnail src={userProfile.profile_image} alt="User1" width={200} height={200} />
+      <UserDetailGroup>
+        <EditUsername
+          defaultValue={userProfile.nickname}
+          value={nicknameValue}
+          onChange={onNicknameChange}
+        />
+        <EditUserDescription
+          defaultValue={userProfile.description}
+          value={descriptionValue}
+          onChange={onDescriptionChange}
+        />
+
+        <ButtonGroup isVisible>
+          <ProfileEditButton type="button" onClick={handleEditFinishBtnClick}>
+            <TextLinkMedium>수정 완료</TextLinkMedium>
+            <Image src={Edit} alt="profile_edit" />
+          </ProfileEditButton>
+        </ButtonGroup>
+      </UserDetailGroup>
+    </UserProfileWrapper>
+  );
+}

--- a/frontend/components/study/EditUserProfile/styled.ts
+++ b/frontend/components/study/EditUserProfile/styled.ts
@@ -1,0 +1,79 @@
+import Image from 'next/image';
+
+import styled from 'styled-components';
+
+export const UserProfileWrapper = styled.div`
+  width: 100%;
+  margin: 40px 0 20px;
+  display: flex;
+  align-items: flex-end;
+  /* justify-content: flex-start; */
+`;
+
+export const UserThumbnail = styled(Image)`
+  width: 200px;
+  height: 200px;
+  border-radius: 100%;
+  border: 1px solid var(--grey-01-color);
+`;
+
+export const UserDetailGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 30px;
+  /* background-color: red; */
+`;
+
+export const Input = styled.input`
+  padding: 4px;
+  width: auto;
+  box-sizing: border-box;
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 400;
+  border: 1px solid var(--grey-02-color);
+  border-radius: 10px;
+  color: var(--title-active-color);
+  outline: none;
+  margin: 5px 0;
+`;
+
+export const EditUsername = styled(Input)`
+  font-size: 18px;
+  line-height: 24px;
+  width: 180px;
+`;
+
+export const EditUserDescription = styled(Input)`
+  font-size: 14px;
+  line-height: 20px;
+  width: 340px;
+`;
+
+export const ButtonGroup = styled.div<{ isVisible: boolean }>`
+  display: flex;
+  gap: 8px;
+  ${(props) => (props.isVisible ? '' : 'visibility : hidden')}
+`;
+
+const Button = styled.button`
+  padding: 4px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  margin: 20px 0 30px;
+`;
+
+export const ProfileEditButton = styled(Button)`
+  width: 120px;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  border-radius: 10px;
+  border: 1px solid var(--grey-01-color);
+`;
+
+export const LogoutButton = styled(Button)`
+  border: 1px solid var(--grey-01-color);
+`;

--- a/frontend/components/study/EditUserProfile/styled.ts
+++ b/frontend/components/study/EditUserProfile/styled.ts
@@ -64,7 +64,7 @@ const Button = styled.button`
 `;
 
 export const ProfileEditButton = styled(Button)`
-  width: 120px;
+  padding: 0 10px;
   height: 40px;
   display: flex;
   justify-content: space-between;
@@ -76,4 +76,18 @@ export const ProfileEditButton = styled(Button)`
 
 export const LogoutButton = styled(Button)`
   border: 1px solid var(--grey-01-color);
+`;
+
+export const EditThumbnailIcon = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100%;
+  padding: 10px;
+  box-sizing: content-box;
+  border: 1px solid var(--grey-01-color);
+  transform: translate(380%, -100%);
+  background-color: var(--light-yellow-color);
+  cursor: pointer;
 `;

--- a/frontend/components/study/EditUserProfile/styled.ts
+++ b/frontend/components/study/EditUserProfile/styled.ts
@@ -10,6 +10,8 @@ export const UserProfileWrapper = styled.div`
   /* justify-content: flex-start; */
 `;
 
+export const UserThumbnailGroup = styled.div``;
+
 export const UserThumbnail = styled(Image)`
   width: 200px;
   height: 200px;

--- a/frontend/components/study/UserProfile/index.tsx
+++ b/frontend/components/study/UserProfile/index.tsx
@@ -44,7 +44,7 @@ export default function UserProfile({ userProfile }: UserProfileProps) {
       ...user,
     });
     router.push('/');
-  }, user);
+  }, [user]);
 
   return (
     <UserProfileWrapper>

--- a/frontend/components/study/UserProfile/index.tsx
+++ b/frontend/components/study/UserProfile/index.tsx
@@ -25,9 +25,10 @@ import {
 
 interface UserProfileProps {
   userProfile: IUser;
+  handleEditBtnClick: () => void;
 }
 
-export default function UserProfile({ userProfile }: UserProfileProps) {
+export default function UserProfile({ userProfile, handleEditBtnClick }: UserProfileProps) {
   const router = useRouter();
 
   const [signInStatus, setSignInStatus] = useRecoilState(signInStatusState);
@@ -54,7 +55,7 @@ export default function UserProfile({ userProfile }: UserProfileProps) {
         <UserDescription>{userProfile.description}</UserDescription>
 
         <ButtonGroup isVisible={signInStatus.id !== 0 && signInStatus.id === userProfile.id}>
-          <ProfileEditButton type="button">
+          <ProfileEditButton type="button" onClick={handleEditBtnClick}>
             <TextLinkMedium>프로필 수정</TextLinkMedium>
             <Image src={Edit} alt="profile_edit" />
           </ProfileEditButton>

--- a/frontend/components/study/UserProfile/index.tsx
+++ b/frontend/components/study/UserProfile/index.tsx
@@ -24,11 +24,11 @@ import {
 } from './styled';
 
 interface UserProfileProps {
-  userProfile: IUser;
+  curUserProfile: IUser;
   handleEditBtnClick: () => void;
 }
 
-export default function UserProfile({ userProfile, handleEditBtnClick }: UserProfileProps) {
+export default function UserProfile({ curUserProfile, handleEditBtnClick }: UserProfileProps) {
   const router = useRouter();
 
   const [signInStatus, setSignInStatus] = useRecoilState(signInStatusState);
@@ -49,12 +49,12 @@ export default function UserProfile({ userProfile, handleEditBtnClick }: UserPro
 
   return (
     <UserProfileWrapper>
-      <UserThumbnail src={userProfile.profile_image} alt="User1" width={200} height={200} />
+      <UserThumbnail src={curUserProfile.profile_image} alt="User1" width={200} height={200} />
       <UserDetailGroup>
-        <Username>{userProfile.nickname}</Username>
-        <UserDescription>{userProfile.description}</UserDescription>
+        <Username>{curUserProfile.nickname}</Username>
+        <UserDescription>{curUserProfile.description}</UserDescription>
 
-        <ButtonGroup isVisible={signInStatus.id !== 0 && signInStatus.id === userProfile.id}>
+        <ButtonGroup isVisible={signInStatus.id !== 0 && signInStatus.id === curUserProfile.id}>
           <ProfileEditButton type="button" onClick={handleEditBtnClick}>
             <TextLinkMedium>프로필 수정</TextLinkMedium>
             <Image src={Edit} alt="profile_edit" />

--- a/frontend/components/study/UserProfile/index.tsx
+++ b/frontend/components/study/UserProfile/index.tsx
@@ -7,9 +7,9 @@ import { useRecoilState } from 'recoil';
 
 import { signOutApi } from '@apis/authApi';
 import Edit from '@assets/ico_edit.svg';
-import User1 from '@assets/ico_user1.svg';
 import signInStatusState from '@atoms/signInStatus';
 import useFetch from '@hooks/useFetch';
+import { IUser } from '@interfaces';
 import { TextLinkMedium } from '@styles/common';
 
 import {
@@ -23,7 +23,11 @@ import {
   UserThumbnail,
 } from './styled';
 
-export default function UserProfile() {
+interface UserProfileProps {
+  userProfile: IUser;
+}
+
+export default function UserProfile({ userProfile }: UserProfileProps) {
   const router = useRouter();
 
   const [signInStatus, setSignInStatus] = useRecoilState(signInStatusState);
@@ -44,12 +48,12 @@ export default function UserProfile() {
 
   return (
     <UserProfileWrapper>
-      <UserThumbnail src={User1} alt="User1" />
+      <UserThumbnail src={userProfile.profile_image} alt="User1" width={200} height={200} />
       <UserDetailGroup>
-        <Username>Web01</Username>
-        <UserDescription>안녕하세요 Web01입니다.</UserDescription>
+        <Username>{userProfile.nickname}</Username>
+        <UserDescription>{userProfile.description}</UserDescription>
 
-        <ButtonGroup isVisible={signInStatus.id !== 0}>
+        <ButtonGroup isVisible={signInStatus.id !== 0 && signInStatus.id === userProfile.id}>
           <ProfileEditButton type="button">
             <TextLinkMedium>프로필 수정</TextLinkMedium>
             <Image src={Edit} alt="profile_edit" />

--- a/frontend/interfaces/user.interface.ts
+++ b/frontend/interfaces/user.interface.ts
@@ -2,4 +2,5 @@ export interface IUser {
   id: number;
   nickname: string;
   profile_image: string;
+  description: string;
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,16 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'kr.object.ncloudstorage.com',
+        port: '',
+        pathname: '/j027/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 
 import { useEffect, useState } from 'react';
 
-import { getUserProfileApi } from '@apis/userApi';
+import { getUserProfileApi, updateUserProfileApi } from '@apis/userApi';
 import GNB from '@components/common/GNB';
 import BookListTab from '@components/study/BookListTab';
 import EditUserProfile from '@components/study/EditUserProfile';
@@ -15,6 +15,7 @@ import { PageInnerLarge, PageWrapper } from '@styles/layout';
 export default function Study() {
   const router = useRouter();
   const { data: userProfile, execute: getUserProfile } = useFetch(getUserProfileApi);
+  const { execute: updateUserProfile } = useFetch(updateUserProfileApi);
   const [curUserProfile, setCurUserProfile] = useState<IUser | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
@@ -43,6 +44,7 @@ export default function Study() {
               <EditUserProfile
                 handleEditFinishBtnClick={() => {
                   setIsEditing(false);
+                  updateUserProfile(curUserProfile);
                 }}
                 curUserProfile={curUserProfile}
                 setCurUserProfile={setCurUserProfile}

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -18,7 +18,7 @@ import { PageInnerLarge, PageWrapper } from '@styles/layout';
 export default function Study() {
   const router = useRouter();
   const { data: userProfile, execute: getUserProfile } = useFetch(getUserProfileApi);
-  const { execute: updateUserProfile } = useFetch(updateUserProfileApi);
+  const { data: updatedUserProfile, execute: updateUserProfile } = useFetch(updateUserProfileApi);
   const [signInStatus, setSignInStatus] = useRecoilState(signInStatusState);
   const [curUserProfile, setCurUserProfile] = useState<IUser | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -26,13 +26,7 @@ export default function Study() {
   const handleEditFinishBtnClick = () => {
     if (!curUserProfile) return;
 
-    setIsEditing(false);
     updateUserProfile(curUserProfile);
-    setSignInStatus({
-      ...signInStatus,
-      nickname: curUserProfile.nickname,
-    });
-    window.history.pushState(null, '', `/study/${curUserProfile.nickname}`);
   };
 
   useEffect(() => {
@@ -49,6 +43,17 @@ export default function Study() {
       ...userProfile,
     });
   }, [userProfile]);
+
+  useEffect(() => {
+    if (updatedUserProfile === undefined || !curUserProfile) return;
+
+    setIsEditing(false);
+    setSignInStatus({
+      ...signInStatus,
+      nickname: curUserProfile.nickname,
+    });
+    window.history.pushState(null, '', `/study/${curUserProfile.nickname}`);
+  }, [updatedUserProfile]);
 
   return (
     <>

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -1,18 +1,22 @@
 import { useRouter } from 'next/router';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { getUserProfileApi } from '@apis/userApi';
 import GNB from '@components/common/GNB';
 import BookListTab from '@components/study/BookListTab';
+import EditUserProfile from '@components/study/EditUserProfile';
 import FAB from '@components/study/FAB';
 import UserProfile from '@components/study/UserProfile';
 import useFetch from '@hooks/useFetch';
+import { IUser } from '@interfaces';
 import { PageInnerLarge, PageWrapper } from '@styles/layout';
 
 export default function Study() {
   const router = useRouter();
   const { data: userProfile, execute: getUserProfile } = useFetch(getUserProfileApi);
+  const [curUserProfile, setCurUserProfile] = useState<IUser | null>(null);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
 
   useEffect(() => {
     if (!router.query.data) return;
@@ -21,13 +25,35 @@ export default function Study() {
     getUserProfile(nickname);
   }, [router.query.data]);
 
+  useEffect(() => {
+    setCurUserProfile({
+      ...userProfile,
+    });
+  }, [userProfile]);
+
   return (
     <>
       <GNB />
-      {userProfile && (
+      {curUserProfile && (
         <PageWrapper>
           <PageInnerLarge>
-            <UserProfile userProfile={userProfile} />
+            {isEditing ? (
+              <EditUserProfile
+                userProfile={curUserProfile}
+                handleEditFinishBtnClick={() => {
+                  setIsEditing(false);
+                }}
+                curUserProfile={curUserProfile}
+                setCurUserProfile={setCurUserProfile}
+              />
+            ) : (
+              <UserProfile
+                userProfile={curUserProfile}
+                handleEditBtnClick={() => {
+                  setIsEditing(true);
+                }}
+              />
+            )}
             <BookListTab />
           </PageInnerLarge>
           <FAB />

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -26,6 +26,8 @@ export default function Study() {
   }, [router.query.data]);
 
   useEffect(() => {
+    if (!userProfile) return;
+
     setCurUserProfile({
       ...userProfile,
     });
@@ -39,7 +41,6 @@ export default function Study() {
           <PageInnerLarge>
             {isEditing ? (
               <EditUserProfile
-                userProfile={curUserProfile}
                 handleEditFinishBtnClick={() => {
                   setIsEditing(false);
                 }}
@@ -48,7 +49,7 @@ export default function Study() {
               />
             ) : (
               <UserProfile
-                userProfile={curUserProfile}
+                curUserProfile={curUserProfile}
                 handleEditBtnClick={() => {
                   setIsEditing(true);
                 }}

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -19,6 +19,11 @@ export default function Study() {
   const [curUserProfile, setCurUserProfile] = useState<IUser | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
+  const handleEditFinishBtnClick = () => {
+    setIsEditing(false);
+    updateUserProfile(curUserProfile);
+  };
+
   useEffect(() => {
     if (!router.query.data) return;
 
@@ -42,10 +47,7 @@ export default function Study() {
           <PageInnerLarge>
             {isEditing ? (
               <EditUserProfile
-                handleEditFinishBtnClick={() => {
-                  setIsEditing(false);
-                  updateUserProfile(curUserProfile);
-                }}
+                handleEditFinishBtnClick={handleEditFinishBtnClick}
                 curUserProfile={curUserProfile}
                 setCurUserProfile={setCurUserProfile}
               />

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -52,7 +52,7 @@ export default function Study() {
       ...signInStatus,
       nickname: curUserProfile.nickname,
     });
-    window.history.pushState(null, '', `/study/${curUserProfile.nickname}`);
+    window.history.replaceState(null, '', `/study/${curUserProfile.nickname}`);
   }, [updatedUserProfile]);
 
   return (

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -1,23 +1,38 @@
+import { useRouter } from 'next/router';
+
+import { useEffect } from 'react';
+
+import { getUserProfileApi } from '@apis/userApi';
 import GNB from '@components/common/GNB';
 import BookListTab from '@components/study/BookListTab';
 import FAB from '@components/study/FAB';
 import UserProfile from '@components/study/UserProfile';
+import useFetch from '@hooks/useFetch';
 import { PageInnerLarge, PageWrapper } from '@styles/layout';
 
 export default function Study() {
-  // 파일은 따로 잡기는 했는데 router.query.data에 담겨있는 닉네임을 읽어서
-  // API 요청해서 UserProfile에 정보 넘겨줘야 함
+  const router = useRouter();
+  const { data: userProfile, execute: getUserProfile } = useFetch(getUserProfileApi);
+
+  useEffect(() => {
+    if (!router.query.data) return;
+
+    const nickname = router.query.data;
+    getUserProfile(nickname);
+  }, [router.query.data]);
 
   return (
     <>
       <GNB />
-      <PageWrapper>
-        <PageInnerLarge>
-          <UserProfile />
-          <BookListTab />
-        </PageInnerLarge>
-        <FAB />
-      </PageWrapper>
+      {userProfile && (
+        <PageWrapper>
+          <PageInnerLarge>
+            <UserProfile userProfile={userProfile} />
+            <BookListTab />
+          </PageInnerLarge>
+          <FAB />
+        </PageWrapper>
+      )}
     </>
   );
 }

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -2,7 +2,10 @@ import { useRouter } from 'next/router';
 
 import { useEffect, useState } from 'react';
 
+import { useRecoilState } from 'recoil';
+
 import { getUserProfileApi, updateUserProfileApi } from '@apis/userApi';
+import signInStatusState from '@atoms/signInStatus';
 import GNB from '@components/common/GNB';
 import BookListTab from '@components/study/BookListTab';
 import EditUserProfile from '@components/study/EditUserProfile';
@@ -16,12 +19,20 @@ export default function Study() {
   const router = useRouter();
   const { data: userProfile, execute: getUserProfile } = useFetch(getUserProfileApi);
   const { execute: updateUserProfile } = useFetch(updateUserProfileApi);
+  const [signInStatus, setSignInStatus] = useRecoilState(signInStatusState);
   const [curUserProfile, setCurUserProfile] = useState<IUser | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
   const handleEditFinishBtnClick = () => {
+    if (!curUserProfile) return;
+
     setIsEditing(false);
     updateUserProfile(curUserProfile);
+    setSignInStatus({
+      ...signInStatus,
+      nickname: curUserProfile.nickname,
+    });
+    window.history.pushState(null, '', `/study/${curUserProfile.nickname}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 개요

서재 페이지에서 로그인 정보에 따라서 프로필을 확인하고 수정할 수 있다

## 변경 사항

- User 스키마에 description이 빠져있었어서 추가했습니다 ( pull하신 후에 migrate,generate 해주세요!! )
- 해당 서재의 userId를 바탕으로 프로필 정보를 가져와서 보여준다
- 현재 로그인한 유저와 해당 서재의 유저가 같은 경우에 프로필 수정 및 로그아웃을 활설화해준다
- 프로필 수정 버튼을 눌러서 이미지, 닉네임, 설명란을 수정할 수 있다.

## 참고 사항

### nickname 변경으로 인한 부가 사항 발생
- 우선 DB에서 유니크하게 관리하는 nickname을 수정하는 것이 조금은
- url 관리를 닉네임으로 하다 보니 닉네임을 수정했을 때 window.history를 이용해서 url만 변경하도록 구현하였습니다. 해당 유저의 정보를 수정한다고 해서 로그인 상태에 대한 변화가 일어나지 않기 떄문에 이건 UserProfile 컴포넌트만 리렌더링되면 될 것이라고 생각했습니다. 그런데 url 자체를 닉네임으로 구분하고 있다 보니 닉네임이 변경되었을 때 url 자체도 변경이 되어야 하고 그러면 전체 페이지가 전체 리로딩 되는데 이는 비효율적이라고 판단했습니다. 그래서 url만 변경되고 페이지 렌더링 시키지않는 window.history를 사용했는데 이것이 적합한지는 모르겠습니다
- 현재 전역 로그인 상태 유지에서 토큰의 페이로드에 담겨있는 nickname을 꺼내서 그걸 저장하는데 nickname을 변경한 뒤 새로고침을 하고 자기 서재로 이동하려고 하면 전역에 남아있는 nickname이 변경된 nickname과 다르기 때문에 에러가 발생합니다. 해결하자면 새로운 닉네임을 담아서 토큰을 새롭게 설정하거나 GET /auth를 했을때 페이로드에 담긴 id만 쓰고 닉네임은 찾아와서 res에 보내주는 방법이 있을 것 같은데 비효율적인 방식인 것 같습니다.

💡 개인적으로 url 자체에는 id가 오고 해당 id 유저의 nickname으로 rewrite하는 방법이 되어야 하지 않나라는 생각이 다시 들었습니다..

## 추가 의문 사항
- useFetch에서 동작을 시켰는데 에러가 떠서 토스트 메시지가 뜨는 것뿐 아니라 이후의 연쇄 동작을 막아야 하는데 어떻게 할 수 있을까요...? `study`/`[...data].tsx`/`handleEditFinishBtnClick` 부분 확인해주시면 됩니다! 의도는 다른 사람이 쓰고 있는 닉네임으로 수정했을 시에 에러가 발생해서 토스트 메시지는 발생할 뿐 아니라 이후 동작을 막으려고 하는데 어떻게 막는지 몰라서 여쭤봅니다,,,
- useEffect에서 `if(!~~) return` 형식의 방어를 빈번하게 쓰고 있는데 이전에 React로만 할 때는 사용하지 않던 코드 습관이라 혹시 제가 잘못 코드를 작성하고 있나 싶어서 같이 봐주시면 감사하겠습니다 : )

## 스크린샷

![프로필](https://user-images.githubusercontent.com/67371123/204586364-04543617-6527-4b20-b686-224c4f073da9.gif)


## 관련 이슈

- closes #119 
- closes #121
