### PR TITLE
GitHub Code Owners 추가

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,1 @@
+@doputer @dahyeon405 @MinHK4 @parkhyeonki


### PR DESCRIPTION
## 개요

PR시 자동으로 리뷰어 지정을 하는 스크립트를 추가했습니다.

## 변경 사항

- `./github/codeowners` 추가

## 참고 사항

- [Github Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
