### PR TITLE
책 생성 기능 & 피드백 반영

### DIFF
--- a/backend/src/apis/books/books.controller.ts
+++ b/backend/src/apis/books/books.controller.ts
@@ -34,7 +34,7 @@ const createBook = async (req: Request, res: Response) => {
 
   const book = await booksService.createBook({ title, userId });
 
-  res.status(200).send(book);
+  res.status(201).send(book);
 };
 
 export default {

--- a/frontend/apis/bookApi.ts
+++ b/frontend/apis/bookApi.ts
@@ -38,3 +38,10 @@ export const getUserKnottedBooksApi = async (nickname: string) => {
 
   return response.data;
 };
+export const addBookApi = async (data: { title: string }) => {
+  const url = `/api/books`;
+
+  const response = await api({ url, method: 'POST', data });
+
+  return response.data;
+};

--- a/frontend/components/common/Book/index.tsx
+++ b/frontend/components/common/Book/index.tsx
@@ -24,7 +24,7 @@ import {
 
 interface BookProps {
   book: IBookScraps;
-  handleEditBookModalOpen?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleEditBookModalOpen?: () => void;
 }
 
 export default function Book({ book, handleEditBookModalOpen }: BookProps) {
@@ -37,7 +37,7 @@ export default function Book({ book, handleEditBookModalOpen }: BookProps) {
 
   return (
     // 수정모드일때만 아래 onclick이 실행되도록 수정해야함 -> 민형님 작업 후
-    <BookWrapper onClick={handleEditBookModalOpen} data-book={JSON.stringify(book)}>
+    <BookWrapper onClick={handleEditBookModalOpen}>
       <BookThumbnail src={SampleThumbnail} alt="thumbnail" />
 
       <BookInfoContainer>

--- a/frontend/components/study/AddBook/index.tsx
+++ b/frontend/components/study/AddBook/index.tsx
@@ -1,9 +1,15 @@
+import { useEffect } from 'react';
+
 import { useRecoilValue } from 'recoil';
 
+import { addBookApi } from '@apis/bookApi';
 import SampleThumbnail from '@assets/img_sample_thumbnail.jpg';
 import signInStatusState from '@atoms/signInStatus';
 import Button from '@components/common/Modal/ModalButton';
+import useFetch from '@hooks/useFetch';
+import useInput from '@hooks/useInput';
 import { FlexSpaceBetween } from '@styles/layout';
+import { toastSuccess } from '@utils/toast';
 
 import {
   BookWrapper,
@@ -18,8 +24,20 @@ import {
   BookContent,
 } from './styled';
 
-export default function AddBook() {
+export default function AddBook(handleModalClose: () => void) {
   const user = useRecoilValue(signInStatusState);
+  const title = useInput('');
+  const { data: addBookData, execute: addBook } = useFetch(addBookApi);
+
+  useEffect(() => {
+    if (!addBookData) return;
+    handleModalClose();
+    toastSuccess(`${addBookData.title}책이 추가되었습니다!`);
+  }, [addBookData]);
+
+  const handleAddBookBtnClick = () => {
+    addBook({ title: title.value });
+  };
   return (
     <>
       <BookWrapper>
@@ -28,11 +46,7 @@ export default function AddBook() {
         <BookInfoContainer>
           <FlexSpaceBetween>
             <BookTitle>
-              <Input
-                type="text"
-                placeholder="제목을 입력하세요."
-                onChange={(e) => console.log(e.target.value)}
-              />
+              <Input type="text" placeholder="제목을 입력하세요." {...title} />
               <Author>by {user.nickname}</Author>
             </BookTitle>
           </FlexSpaceBetween>
@@ -44,7 +58,7 @@ export default function AddBook() {
           </BookContentsInfo>
         </BookInfoContainer>
       </BookWrapper>
-      <Button theme="primary" onClick={() => console.log('책추가!')}>
+      <Button theme="primary" onClick={handleAddBookBtnClick}>
         책 추가하기
       </Button>
     </>

--- a/frontend/components/study/AddBook/index.tsx
+++ b/frontend/components/study/AddBook/index.tsx
@@ -40,7 +40,7 @@ export default function AddBook({ handleModalClose }: AddBookProps) {
   useEffect(() => {
     if (!addBookData) return;
     handleModalClose();
-    // 토스트 메세지, reload 중 어떤 방식으로 처리해야할까?
+    // 토스트 메세지, reload 중 어떤 방식으로 처리해야할까? -> 우선 민형님 작업이 끝나고 합치면서 확정예정
     toastSuccess(`${addBookData.title}책이 추가되었습니다!`);
     router.reload();
   }, [addBookData]);

--- a/frontend/components/study/AddBook/index.tsx
+++ b/frontend/components/study/AddBook/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import { useEffect } from 'react';
 
 import { useRecoilValue } from 'recoil';
@@ -24,15 +26,23 @@ import {
   BookContent,
 } from './styled';
 
-export default function AddBook(handleModalClose: () => void) {
+interface AddBookProps {
+  handleModalClose: () => void;
+}
+
+export default function AddBook({ handleModalClose }: AddBookProps) {
   const user = useRecoilValue(signInStatusState);
   const title = useInput('');
   const { data: addBookData, execute: addBook } = useFetch(addBookApi);
 
+  const router = useRouter();
+
   useEffect(() => {
     if (!addBookData) return;
     handleModalClose();
+    // 토스트 메세지, reload 중 어떤 방식으로 처리해야할까?
     toastSuccess(`${addBookData.title}책이 추가되었습니다!`);
+    router.reload();
   }, [addBookData]);
 
   const handleAddBookBtnClick = () => {

--- a/frontend/components/study/BookListTab/index.tsx
+++ b/frontend/components/study/BookListTab/index.tsx
@@ -22,19 +22,15 @@ export default function BookListTab() {
     getNewestBookList('newest');
   }, []);
 
-  const handleEditBookModalOpen = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Html Dataset에는 객체를 담을 수 없어서 JSON을 통해 받음
-    if (!e.currentTarget.dataset.book) return;
+  const handleEditBookModalOpen = (id: number) => {
+    const curbook = newestBookList?.find((v) => v.id === id);
+    if (!curbook) return;
     setModalShown(true);
-    setCurEditBook(JSON.parse(e.currentTarget.dataset.book));
-    // setCurrentModalState('EditBook');
+    setCurEditBook(curbook);
   };
   const handleModalClose = () => {
     setModalShown(false);
-    // setCurrentModalState('EditBook');
   };
-  // const handleEditBookClicked = () => setCurrentModalState('EditBook');
-  // const handleAddBookClicked = () => setCurrentModalState('AddBook');
 
   return (
     <BookListTabWrapper>
@@ -45,7 +41,13 @@ export default function BookListTab() {
       <BookGrid>
         {newestBookList &&
           newestBookList.map((book) => (
-            <Book key={book.id} book={book} handleEditBookModalOpen={handleEditBookModalOpen} />
+            <Book
+              key={book.id}
+              book={book}
+              handleEditBookModalOpen={() => {
+                handleEditBookModalOpen(book.id);
+              }}
+            />
           ))}
       </BookGrid>
       {isModalShown && (

--- a/frontend/components/study/BookListTab/index.tsx
+++ b/frontend/components/study/BookListTab/index.tsx
@@ -12,7 +12,6 @@ import { BookGrid, BookListTabWrapper, TabTitle, TabTitleContent } from './style
 export default function BookListTab() {
   // 일단 에러 안 뜨게 새로 엮은 책 보여주기
   const [isModalShown, setModalShown] = useState(false);
-  // const [currentModalState, setCurrentModalState] = useState<'EditBook' | 'AddBook'>('EditBook');
   const [curEditBook, setCurEditBook] = useState<IBookScraps | null>(null);
 
   const { data: newestBookList, execute: getNewestBookList } =

--- a/frontend/components/study/FAB/index.tsx
+++ b/frontend/components/study/FAB/index.tsx
@@ -29,7 +29,7 @@ export default function FAB() {
       </FabButton>
       {isModalShown && (
         <Modal title="책 추가하기" handleModalClose={handleModalClose}>
-          <AddBook />
+          <AddBook handleModalClose={handleModalClose} />
         </Modal>
       )}
     </FabWrapper>


### PR DESCRIPTION
## 개요

책 생성 기능, 데일리스크럼 피드백 수정
- #150 
- #151 

## 변경 사항

- 책 생성 클라이언트쪽에서 요청 기능 추가
- dataset 삭제 및 수정
- 백엔드 http 상태코드 변경

## 참고 사항

- 책 생성 후 토스트메세지로 알려주고 있으나, reload가 없으면 책이 추가된 내용을 확인할 수 없습니다.
- 우선 두개의 로직 모두 적용시켜두고, 민형님쪽에서 작업이 끝나면 최종 결정 예정입니다!
- 토스트 메세지를 띄우고 책탭만 새로 데이터를 받아서 띄우는 작업이 가장 좋을 것 같은데 상태 추가 말고는 좋은 방법이 떠오르지 않네요.
- 좋은 의견이 있으시면 말씀 부탁드립니다!

## 스크린샷

화면 기록 2022-11-30 오후 1.53.10

## 관련 이슈

- #138 
