### PR TITLE
UI 수정 작업

### DIFF
--- a/frontend/components/common/Book/index.tsx
+++ b/frontend/components/common/Book/index.tsx
@@ -63,7 +63,9 @@ export default function Book({ book, handleEditBookModalOpen }: BookProps) {
               (scrap, idx) =>
                 idx < 4 && (
                   <ArticleLink key={scrap.article.id} href={`/viewer/${id}/${scrap.article.id}`}>
-                    {idx + 1}. {scrap.article.title}
+                    <span>
+                      {idx + 1}. {scrap.article.title}
+                    </span>
                   </ArticleLink>
                 )
             )}

--- a/frontend/components/common/Book/styled.ts
+++ b/frontend/components/common/Book/styled.ts
@@ -58,21 +58,25 @@ export const BookContentsInfo = styled(FlexColumn)`
 export const BookContents = styled(TextXSmall)`
   display: flex;
   flex-direction: column;
-
-  a {
-    border-bottom: 1px solid var(--grey-02-color);
-    height: 28px;
-    display: flex;
-    align-items: center;
-  }
 `;
 
 export const ArticleLink = styled(Link)`
   font-size: 14px;
-  line-height: 20px;
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
+  align-items: center;
+
+  border-bottom: 1px solid var(--grey-02-color);
+  height: 28px;
+
+  span {
+    line-height: 30px;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 export const AuthorLink = styled(Link)`

--- a/frontend/components/common/Content/styled.ts
+++ b/frontend/components/common/Content/styled.ts
@@ -11,6 +11,8 @@ export const ContentTitle = styled.h1`
 `;
 
 export const ContentBody = styled.div`
+  padding-top: 10px;
+
   > * {
     line-height: 1.4;
   }

--- a/frontend/components/common/GNB/styled.ts
+++ b/frontend/components/common/GNB/styled.ts
@@ -1,9 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import styled from 'styled-components';
-
 import { TopBar } from '@styles/layout';
+import styled from 'styled-components';
 
 export const GNBbar = styled(TopBar)`
   width: 100%;
@@ -11,7 +10,7 @@ export const GNBbar = styled(TopBar)`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 4px 50px;
+  padding: 4px 30px;
   box-sizing: border-box;
   background-color: var(--light-yellow-color);
 `;
@@ -20,7 +19,7 @@ export const Logo = styled(Link)`
   font-family: 'Sofia';
   font-style: normal;
   font-weight: 500;
-  font-size: 44px;
+  font-size: 32px;
   line-height: 57px;
   color: var(--title-active-color);
   text-decoration: none;

--- a/frontend/components/common/GNB/styled.ts
+++ b/frontend/components/common/GNB/styled.ts
@@ -1,8 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { TopBar } from '@styles/layout';
 import styled from 'styled-components';
+
+import { TopBar } from '@styles/layout';
 
 export const GNBbar = styled(TopBar)`
   width: 100%;
@@ -26,7 +27,7 @@ export const Logo = styled(Link)`
 `;
 
 export const IconsContainer = styled.div`
-  width: 112px;
+  width: 96px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/components/common/Modal/styled.ts
+++ b/frontend/components/common/Modal/styled.ts
@@ -14,14 +14,15 @@ export const ModalWrapper = styled.div`
   top: 0px;
   left: 0px;
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
+  align-items: center;
   z-index: 99;
 `;
 
 export const ModalInner = styled.div`
   width: 360px;
-  margin-top: 150px;
   padding: 32px;
   background: var(--white-color);
   border-radius: 30px;

--- a/frontend/components/home/Slider/styled.ts
+++ b/frontend/components/home/Slider/styled.ts
@@ -17,7 +17,9 @@ export const SliderContent = styled(FlexColumn)`
   margin-top: 30px;
 `;
 
-export const SliderInfoContainer = styled(FlexSpaceBetween)``;
+export const SliderInfoContainer = styled(FlexSpaceBetween)`
+  padding: 0px 10px;
+`;
 
 export const SliderInfo = styled.div`
   display: flex;

--- a/frontend/components/search/SearchBar/index.tsx
+++ b/frontend/components/search/SearchBar/index.tsx
@@ -12,7 +12,7 @@ interface SearchBarProps {
 export default function SearchBar({ value, onChange }: SearchBarProps) {
   return (
     <SearchBarWrapper>
-      <SearchBarInput value={value} onChange={onChange} />
+      <SearchBarInput value={value} onChange={onChange} placeholder="검색어를 입력해주세요." />
       <Image src={SearchIcon} alt="Search Icon" />
     </SearchBarWrapper>
   );

--- a/frontend/components/search/SearchBar/styled.ts
+++ b/frontend/components/search/SearchBar/styled.ts
@@ -15,4 +15,5 @@ export const SearchBarInput = styled.input`
   border: none;
   outline: none;
   font-size: 32px;
+  font-family: Noto Sans KR;
 `;

--- a/frontend/components/search/SearchNoResult/index.tsx
+++ b/frontend/components/search/SearchNoResult/index.tsx
@@ -1,0 +1,5 @@
+import NoResult from './styled';
+
+export default function SearchNoResult() {
+  return <NoResult>검색 결과가 없습니다.</NoResult>;
+}

--- a/frontend/components/search/SearchNoResult/styled.ts
+++ b/frontend/components/search/SearchNoResult/styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const NoResult = styled.div`
+  font-size: 28px;
+  color: var(--grey-01-color);
+  font-weight: 400;
+  padding-top: 50px;
+`;
+
+export default NoResult;

--- a/frontend/components/viewer/ArticleContent/styled.ts
+++ b/frontend/components/viewer/ArticleContent/styled.ts
@@ -9,12 +9,14 @@ export const ArticleContainer = styled(Flex)`
 export const ArticleLeftBtn = styled.div`
   position: fixed;
   top: 50%;
-  margin-left: 10px;
+  margin-left: 20px;
+  cursor: pointer;
 `;
 export const ArticleRightBtn = styled.div`
   position: fixed;
   top: 50%;
   right: 25px;
+  cursor: pointer;
 `;
 export const ArticleMain = styled(Flex)`
   flex-direction: column;

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -43,7 +43,7 @@ export const TocContainer = styled.div`
   background-color: var(--white-color);
   color: var(--grey-01-color);
   border-radius: 20px;
-  padding: 20px;
+  padding: 24px;
   margin-top: 10px;
   overflow: auto;
   height: calc(100vh - 357px);
@@ -58,7 +58,7 @@ export const TocContainer = styled.div`
 `;
 
 export const TocList = styled.div`
-  margin: 5px;
+  margin-top: 10px;
 `;
 
 export const TocArticle = styled(Link)`

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -16,18 +16,18 @@ const slide = keyframes`
 
 export const TocWrapper = styled(Flex)`
   /* 고정크기? %? */
-  flex-basis: 250px;
+  flex-basis: 300px;
   height: calc(100vh - 67px);
+  overflow: hidden;
   background-color: var(--primary-color);
   color: var(--white-color);
   flex-direction: column;
-  position: relative;
+  justify-content: space-between;
   // animation: ${slide} 1s ease-in-out;
 `;
 
 export const TocSideBar = styled.div`
-  padding: 30px;
-  flex-basis: 90%;
+  padding: 30px 24px 10px 24px;
 `;
 
 export const TocIcons = styled(Flex)`
@@ -38,15 +38,25 @@ export const TocTitle = styled.div`
   padding: 10px 0;
   border-bottom: 1px solid var(--white-color);
 `;
+
 export const TocContainer = styled.div`
   background-color: var(--white-color);
-  height: 70%;
   color: var(--grey-01-color);
   border-radius: 20px;
   padding: 20px;
   margin-top: 10px;
   overflow: auto;
+  height: calc(100vh - 357px);
+
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--grey-02-color);
+    border-radius: 10px;
+  }
 `;
+
 export const TocList = styled.div`
   margin: 5px;
 `;
@@ -67,9 +77,9 @@ export const TocArticle = styled(Link)`
 export const TocProfile = styled(Flex)`
   justify-content: end;
   align-items: end;
-  flex-basis: 10%;
   padding: 20px;
 `;
+
 export const TocProfileText = styled(Flex)`
   flex-direction: column;
   align-items: end;

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -7,6 +7,7 @@ import ArticleList from '@components/search/ArticleList';
 import BookList from '@components/search/BookList';
 import SearchBar from '@components/search/SearchBar';
 import SearchFilter from '@components/search/SearchFilter';
+import SearchNoResult from '@components/search/SearchNoResult';
 import useDebounce from '@hooks/useDebounce';
 import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
@@ -106,6 +107,9 @@ export default function Search() {
           <SearchFilter handleFilter={handleFilter} />
           {articles?.length > 0 && filter.type === 'article' && <ArticleList articles={articles} />}
           {books?.length > 0 && filter.type === 'book' && <BookList books={books} />}
+          {debouncedKeyword !== '' &&
+            ((articles?.length === 0 && filter.type === 'article') ||
+              (books?.length === 0 && filter.type === 'book')) && <SearchNoResult />}
           <div ref={target} />
         </PageInnerSmall>
       </PageWrapper>

--- a/frontend/styles/layout.ts
+++ b/frontend/styles/layout.ts
@@ -27,7 +27,7 @@ export const FlexColumnCenter = styled.div`
 
 export const PageWrapper = styled.div`
   padding-top: 64px;
-  min-height: calc(100vh - 67px);
+  min-height: calc(100vh - 131px);
   background-color: var(--light-yellow-color);
 `;
 


### PR DESCRIPTION
## 개요

UI적으로 수정할 만한 부분들을 모아서 수정하였습니다.

## 변경 사항

자세한 변경사항은 commit 내역을 참고해주세요.
- GNB 로고 크기 및 padding, icon 간격을 조정했습니다.
- 모달 top 위치를 고정했던 것에서 수직 중앙 정렬로 변경했습니다.
- 책 컴포넌트 타이틀에 말줄임표가 표시되도록 변경했습니다.
- 뷰어페이지에서 프로필이 TOC를 벗어나는 버그를 수정하였습니다.
- 검색 결과 없음을 표시하는 컴포넌트를 추가하였습니다.

## 스크린샷

![fix_main](https://user-images.githubusercontent.com/109179856/204982184-0bd6be16-3aff-42c9-aafa-361168509e43.JPG)

![fix_search](https://user-images.githubusercontent.com/109179856/204982191-98afe7b4-fd2f-4f93-a276-2fd305283772.JPG)

![fix_viewer](https://user-images.githubusercontent.com/109179856/204982193-b73d88a6-69e4-4d08-ade4-f370b5aac886.JPG)

![fix_modal](https://user-images.githubusercontent.com/109179856/204982189-fdeb6c2d-e020-4d46-a966-5de79413e042.JPG)
