### PR TITLE
페이지 타이틀, 메타 태그 추가 작업

### DIFF
--- a/frontend/components/edit/EditHead/index.tsx
+++ b/frontend/components/edit/EditHead/index.tsx
@@ -1,0 +1,9 @@
+import Head from 'next/head';
+
+export default function EditHead() {
+  return (
+    <Head>
+      <title>Knoticle</title>
+    </Head>
+  );
+}

--- a/frontend/components/home/HomeHead/index.tsx
+++ b/frontend/components/home/HomeHead/index.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+
+export default function HomeHead() {
+  return (
+    <Head>
+      <title>Knoticle</title>
+      <meta name="description" content="모두의 글을 엮어 만드는 나만의 책, 노티클 📒" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <meta property="og:title" content="Knoticle" />
+      <meta property="og:description" content="모두의 글을 엮어 만드는 나만의 책, 노티클 📒" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://knoticle.app" />
+      <meta property="og:image" content="https://kr.object.ncloudstorage.com/j027/knoticle.png" />
+    </Head>
+  );
+}

--- a/frontend/components/search/SearchHead/index.tsx
+++ b/frontend/components/search/SearchHead/index.tsx
@@ -1,0 +1,9 @@
+import Head from 'next/head';
+
+export default function SearchHead() {
+  return (
+    <Head>
+      <title>Knoticle</title>
+    </Head>
+  );
+}

--- a/frontend/components/study/StudyHead/index.tsx
+++ b/frontend/components/study/StudyHead/index.tsx
@@ -1,0 +1,22 @@
+import Head from 'next/head';
+
+interface StudyHeadProps {
+  userNickname: string;
+  userDescription: string;
+  userImage: string;
+}
+
+export default function StudyHead({ userNickname, userDescription, userImage }: StudyHeadProps) {
+  return (
+    <Head>
+      <title>{`${userNickname} - Knoticle`}</title>
+      <meta name="description" content={`${userDescription}`} />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <meta property="og:title" content={`${userNickname} - Knoticle`} />
+      <meta property="og:description" content={`${userDescription}`} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://knoticle.app" />
+      <meta property="og:image" content={`${userImage}`} />
+    </Head>
+  );
+}

--- a/frontend/components/viewer/ViewerHead/index.tsx
+++ b/frontend/components/viewer/ViewerHead/index.tsx
@@ -1,0 +1,21 @@
+import Head from 'next/head';
+
+interface ViewerHeadProps {
+  articleTitle: string;
+  articleContent: string;
+}
+
+export default function ViewerHead({ articleTitle, articleContent }: ViewerHeadProps) {
+  return (
+    <Head>
+      <title>{articleTitle}</title>
+      <meta name="description" content={articleContent} />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <meta property="og:title" content={articleTitle} />
+      <meta property="og:description" content={articleContent.slice(0, 150)} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://www.knoticle.app" />
+      <meta property="og:image" content="https://kr.object.ncloudstorage.com/j027/knoticle.png" />
+    </Head>
+  );
+}

--- a/frontend/pages/editor.tsx
+++ b/frontend/pages/editor.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { getUserKnottedBooksApi } from '@apis/bookApi';
 import signInStatusState from '@atoms/signInStatus';
 import Modal from '@components/common/Modal';
+import EditHead from '@components/edit/EditHead';
 import Editor from '@components/edit/Editor';
 import PublishModal from '@components/edit/PublishModal';
 import useFetch from '@hooks/useFetch';
@@ -25,6 +26,7 @@ export default function EditorPage() {
 
   return (
     <>
+      <EditHead />
       <Editor handleModalOpen={handleModalOpen} />
       {isModalShown && (
         <Modal title="글 발행하기" handleModalClose={handleModalClose}>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { getOrderedBookListApi } from '@apis/bookApi';
 import Footer from '@components/common/Footer';
 import GNB from '@components/common/GNB';
+import HomeHead from '@components/home/HomeHead';
 import Slider from '@components/home/Slider';
 import useFetch from '@hooks/useFetch';
 import { PageInnerLarge, PageWrapper } from '@styles/layout';
@@ -18,6 +19,7 @@ export default function Home() {
 
   return (
     <>
+      <HomeHead />
       <GNB />
       <PageWrapper>
         <PageInnerLarge>

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -7,6 +7,7 @@ import ArticleList from '@components/search/ArticleList';
 import BookList from '@components/search/BookList';
 import SearchBar from '@components/search/SearchBar';
 import SearchFilter from '@components/search/SearchFilter';
+import SearchHead from '@components/search/SearchHead';
 import SearchNoResult from '@components/search/SearchNoResult';
 import useDebounce from '@hooks/useDebounce';
 import useFetch from '@hooks/useFetch';
@@ -163,6 +164,7 @@ export default function Search() {
 
   return (
     <>
+      <SearchHead />
       <GNB />
       <PageWrapper>
         <PageInnerSmall>

--- a/frontend/pages/study/[...data].tsx
+++ b/frontend/pages/study/[...data].tsx
@@ -3,11 +3,10 @@ import { useRouter } from 'next/router';
 
 import { useEffect, useState } from 'react';
 
-import axios from 'axios';
 import { useRecoilState } from 'recoil';
 
 import { getUserBookmarkedBooksApi, getUserKnottedBooksApi } from '@apis/bookApi';
-import { updateUserProfileApi } from '@apis/userApi';
+import { getUserProfileApi, updateUserProfileApi } from '@apis/userApi';
 import curKnottedBookListState from '@atoms/curKnottedBookList';
 import signInStatusState from '@atoms/signInStatus';
 import GNB from '@components/common/GNB';
@@ -119,11 +118,8 @@ export default function Study({ userProfile }: StudyProps) {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const nickname = context.query.data;
-  const response = await axios.get(
-    `${process.env.NEXT_PUBLIC_SERVER_URL}/api/users?nickname=${nickname}`
-  );
-  const { data } = response;
+  const nickname = context.query.data as string;
+  const data = await getUserProfileApi(nickname);
 
   return { props: { userProfile: data } };
 };


### PR DESCRIPTION
## 개요

SEO 대응 페이지 별 타이틀과 메타 태그를 추가하는 작업을 진행했습니다.

## 변경 사항

- 메인 페이지 타이틀, 메타 태그 추가
- 서재 페이지 타이틀, 메타 태그 추가
- 뷰어 페이지 타이틀, 메타 태그 추가
- 에디터 및 검색 페이지 타이틀 추가

## 참고 사항

- 뷰어 페이지 Head의 경우 아티클 데이터를 getServersideProps로 불러오는 작업이 완료되시면 이를 바탕으로 수정해서 페이지에 넣도록 하겠습니다.
- 뷰어 페이지의 open graph 이미지가 아티클에 포함된 사진으로 수정되면 좋을 것 같은데, 관련 함수는 추후에 따로 만들어서 보완하도록 하겠습니다.

## 스크린샷

배포 후 첨부 예정

## 관련 이슈

- #197 
- #198 
- #199 
- #200 
