### PR TITLE
검색 기능 개선 작업

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,8 +52,6 @@ model Article {
   book_id Int
   scraps Scrap[]
 
-  @@fulltext([content])
-  @@fulltext([title])
   @@fulltext([content, title])
 }
 

--- a/backend/src/apis/articles/articles.service.ts
+++ b/backend/src/apis/articles/articles.service.ts
@@ -49,6 +49,13 @@ const searchArticles = async (searchArticles: SearchArticles) => {
       deleted_at: null,
       ...matchUserCondition,
     },
+    orderBy: {
+      _relevance: {
+        fields: ['title', 'content'],
+        sort: 'desc',
+        search: `${query}*`,
+      },
+    },
     take,
     skip,
   });

--- a/backend/src/apis/books/books.service.ts
+++ b/backend/src/apis/books/books.service.ts
@@ -155,6 +155,13 @@ const searchBooks = async ({ query, userId, take, page }: SearchBooks) => {
         search: `${query}*`,
       },
     },
+    orderBy: {
+      _relevance: {
+        fields: ['title'],
+        sort: 'desc',
+        search: `${query}*`,
+      },
+    },
     skip,
     take,
   });


### PR DESCRIPTION
## 개요

검색 시 검색어와 일치율이 높은 결과가 먼저 나오도록 개선했습니다.

## 변경 사항

- 일치율이 높은게 먼저 보일 수 있도록 `_relevance`를 기준으로 내림차순 정렬

## 참고 사항

- 일치율이 높다는 것은 다음과 같습니다.

검색하려는 키워드가 `어머니 방에` 이고, 데이터베이스에 저장된 내용에서 Full-Text Index가 걸려있는 컬럼의 내용이 다음과 같다고 가정하겠습니다.

```
1. 아버지가 방에 들어가신다
2. 아버지가 차에 들어가신다
3. 어머니가 방에 들어가신다
4. 어머니가 차에 들어가신다
```

추가로 말씀드리겠지만, 저희는 데이터베이스 상에서 기본 Full-Text 파서가 아닌 N-gram 파서를 사용하고, `ngram_token_size = 2` 이기 때문에

```
1. 아버 버지 지가 방에 들어 어가 가신 신다
2. 아버 버지 지가 차에 들어 어가 가신 신다
3. 어머 머니 니가 방에 들어 어가 가신 신다
4. 어머 머니 니가 차에 들어 어가 가신 신다
```

위와 같이 토크나이징되어서 인덱싱 되게 됩니다.

이때 `어머니 방에` 라는 키워드도 마찬가지로 토크나이징되기 때문에

```
어머니 방에 -> 어머 머니 방에
```

위와 같이 되게 됩니다.

이제 느낌이 오시겠지만 토크나이징된 `어머` `머니` `방에` 세 가지 토큰이 가장 많이 일치된 컬럼이 **일치율**이 가장 높은 컬럼이고, 이 일치율을 정렬해서 보여주는 방식으로 해당 작업이 이루어진 것 입니다.

- 초기에는 MATCH...AGAINST 쿼리문을 통해서 보여지는 일치율을 Prisma 메서드에서는 얻을 수 없다고 생각해서 직접 쿼리문을 날리려고 했습니다.

```ts
await prisma.$queryRaw`
  SELECT article.*, book.user_id, user.nickname, user.profile_image, MATCH(article.title, article.content) AGAINST (${query} IN BOOLEAN MODE) AS relevance FROM article
  LEFT JOIN book ON article.book_id = book.id
  LEFT JOIN user ON book.user_id = user.id
  WHERE MATCH(article.title, article.content) AGAINST (${query} IN BOOLEAN MODE) AND article.deleted_at IS NULL
  ORDER BY relevance DESC;
`;
```

- 그런데 추가로 서치해본 결과 Prisma 상에서 위와 같은 쿼리를 날릴 수 있다는 것을 발견해서 적용했습니다. [관련 문서](https://github.com/prisma/prisma/releases/3.5.0)

## 관련 이슈

- #117 
- #120 
