### PR TITLE
서재페이지, 드래그앤드롭 반응형 작업

### DIFF
--- a/frontend/components/common/DragDrop/index.tsx
+++ b/frontend/components/common/DragDrop/index.tsx
@@ -1,5 +1,5 @@
 import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
+import { TouchBackend } from 'react-dnd-touch-backend';
 
 import DragContainer from '@components/common/DragDrop/Container';
 
@@ -20,7 +20,7 @@ export interface ContainerState {
 
 export default function DragArticle({ data, isContentsShown, isDeleteBtnShown }: ContainerState) {
   return (
-    <DndProvider backend={HTML5Backend}>
+    <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
       <DragContainer
         data={data}
         isContentsShown={isContentsShown}

--- a/frontend/components/study/UserProfile/styled.ts
+++ b/frontend/components/study/UserProfile/styled.ts
@@ -6,10 +6,11 @@ import { TextLarge, TextSmall } from '@styles/common';
 
 export const UserProfileWrapper = styled.div`
   width: 100%;
-  margin: 40px 0 20px;
+  margin: 40px 0 20px 40px;
   display: flex;
-  align-items: flex-end;
-  /* justify-content: flex-start; */
+  @media ${(props) => props.theme.mobile} {
+    flex-direction: column;
+  }
 `;
 
 export const UserThumbnail = styled(Image)`
@@ -24,6 +25,9 @@ export const UserDetailGroup = styled.div`
   flex-direction: column;
   margin-left: 30px;
   /* background-color: red; */
+  @media ${(props) => props.theme.mobile} {
+    margin-top: 20px;
+  }
 `;
 
 export const Username = styled(TextLarge)``;

--- a/frontend/components/study/UserProfile/styled.ts
+++ b/frontend/components/study/UserProfile/styled.ts
@@ -10,6 +10,9 @@ export const UserProfileWrapper = styled.div`
   display: flex;
   @media ${(props) => props.theme.mobile} {
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 20px;
   }
 `;
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react": "18.2.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
+        "react-dnd-touch-backend": "^16.0.1",
         "react-dom": "18.2.0",
         "react-toastify": "^9.1.1",
         "recoil": "^0.7.6",
@@ -4989,6 +4990,15 @@
         "dnd-core": "^16.0.1"
       }
     },
+    "node_modules/react-dnd-touch-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-16.0.1.tgz",
+      "integrity": "sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -9687,6 +9697,15 @@
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "requires": {
+        "dnd-core": "^16.0.1"
+      }
+    },
+    "react-dnd-touch-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-16.0.1.tgz",
+      "integrity": "sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==",
+      "requires": {
+        "@react-dnd/invariant": "^4.0.1",
         "dnd-core": "^16.0.1"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
+    "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "18.2.0",
     "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",

--- a/frontend/styles/GlobalStyle.ts
+++ b/frontend/styles/GlobalStyle.ts
@@ -20,8 +20,14 @@ const GlobalStyle = createGlobalStyle`
     color: var(--title-active-color);
     font-family: 'Noto Sans KR';
     font-weight: 500;
+    
+    scrollbar-width: none;
+    -ms-overflow-style: none; 
   }
-
+  body::-webkit-scrollbar {
+    display: none;
+  }
+    
   button {
     border: none;
     background: transparent;


### PR DESCRIPTION
## 개요

서재페이지, 드래그앤드롭 반응형 작업

## 변경 사항

- 서재페이지 프로필 사진 레이아웃 변경(반응형)
- 드래그앤드롭 터치 적용

## 참고 사항

- 서재페이지 프로필사진이 모바일일때 크기가 너무 커서 레이아웃이 망가지는 현상이 발견되었습니다.
- 해당 부분을 개선하기 위해 모바일일때 가로에서 세로로 닉네임,설명,버튼이 내려오도록 구현했습니다.

- 드래그앤드롭 터치와 클릭이벤트 모두 적용되도록 수정했습니다.

## 스크린샷
- 프로
<img width="506" alt="스크린샷 2022-12-08 오전 10 35 46" src="https://user-images.githubusercontent.com/87806611/206334473-d54c6858-1239-4ad4-a42d-c4c886f33eb0.png">
필 사진 수정


- 서재 페이지 반응형 적용

https://user-images.githubusercontent.com/87806611/206200038-3907dc43-00f7-4df0-95d6-90010f30d03f.mov


- 드래그앤드롭 반응형 터치 적용

https://user-images.githubusercontent.com/87806611/206200061-b2c0e245-acdc-4324-abd6-1c37031922e1.mov



## 관련 이슈

- #231 
- #232 
