### PR TITLE
GitHub 로그인 대기 페이지 UI/UX 개선 작업

### DIFF
--- a/frontend/components/SignInModal/styled.ts
+++ b/frontend/components/SignInModal/styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { FlexColumnCenter } from '@styles/layout';
+import { FlexColumnAlignCenter } from '@styles/layout';
 
 export const SignInModalWrapper = styled.div`
   margin-top: 56px;
@@ -10,7 +10,7 @@ export const SignInModalWrapper = styled.div`
   box-sizing: border-box;
 `;
 
-export const SignUpContainer = styled(FlexColumnCenter)`
+export const SignUpContainer = styled(FlexColumnAlignCenter)`
   padding: 20px;
   gap: 10px;
 

--- a/frontend/components/common/Spinner/index.tsx
+++ b/frontend/components/common/Spinner/index.tsx
@@ -1,0 +1,19 @@
+import { SpinnerInner, SpinnerWrapper } from './styled';
+
+interface SpinnerProps {
+  width: number;
+  height: number;
+  borderWidth?: number;
+}
+
+export default function Spinner({ width, height, borderWidth }: SpinnerProps) {
+  return (
+    <SpinnerWrapper width={width} height={height}>
+      <SpinnerInner borderWidth={borderWidth} />
+    </SpinnerWrapper>
+  );
+}
+
+Spinner.defaultProps = {
+  borderWidth: 30,
+};

--- a/frontend/components/common/Spinner/index.tsx
+++ b/frontend/components/common/Spinner/index.tsx
@@ -1,19 +1,19 @@
 import { SpinnerInner, SpinnerWrapper } from './styled';
 
-interface SpinnerProps {
+interface SpinnerStyle {
   width: number;
   height: number;
-  borderWidth?: number;
+  borderWidth: number;
 }
 
-export default function Spinner({ width, height, borderWidth }: SpinnerProps) {
+interface SpinnerProps {
+  style: SpinnerStyle;
+}
+
+export default function Spinner({ style }: SpinnerProps) {
   return (
-    <SpinnerWrapper width={width} height={height}>
-      <SpinnerInner borderWidth={borderWidth} />
+    <SpinnerWrapper width={style.width} height={style.height}>
+      <SpinnerInner borderWidth={style.borderWidth} />
     </SpinnerWrapper>
   );
 }
-
-Spinner.defaultProps = {
-  borderWidth: 30,
-};

--- a/frontend/components/common/Spinner/styled.ts
+++ b/frontend/components/common/Spinner/styled.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+interface SpinnerWrapperProps {
+  width: number;
+  height: number;
+}
+
+export const SpinnerWrapper = styled.div<SpinnerWrapperProps>`
+  width: ${(props) => props.width}px;
+  height: ${(props) => props.height}px;
+`;
+
+interface SpinnerInnerProps {
+  borderWidth?: number;
+}
+
+export const SpinnerInner = styled.div<SpinnerInnerProps>`
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  border: ${(props) => props.borderWidth}px solid var(--grey-02-color);
+  border-top: ${(props) => props.borderWidth}px solid var(--primary-color);
+  border-radius: 50%;
+  box-sizing: border-box;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  animation: spin 1s infinite ease;
+`;

--- a/frontend/components/common/Spinner/styled.ts
+++ b/frontend/components/common/Spinner/styled.ts
@@ -11,7 +11,7 @@ export const SpinnerWrapper = styled.div<SpinnerWrapperProps>`
 `;
 
 interface SpinnerInnerProps {
-  borderWidth?: number;
+  borderWidth: number;
 }
 
 export const SpinnerInner = styled.div<SpinnerInnerProps>`

--- a/frontend/components/study/EditBook/styled.ts
+++ b/frontend/components/study/EditBook/styled.ts
@@ -3,9 +3,9 @@ import Image from 'next/image';
 import styled from 'styled-components';
 
 import { TextXSmall, TextSmall } from '@styles/common';
-import { FlexCenter, FlexColumn, FlexColumnCenter } from '@styles/layout';
+import { FlexCenter, FlexColumn, FlexColumnAlignCenter } from '@styles/layout';
 
-export const EditBookWapper = styled(FlexColumnCenter)`
+export const EditBookWapper = styled(FlexColumnAlignCenter)`
   width: 320px;
   margin: auto;
 `;

--- a/frontend/pages/github.tsx
+++ b/frontend/pages/github.tsx
@@ -6,37 +6,43 @@ import { useSetRecoilState } from 'recoil';
 
 import { githubSignInApi } from '@apis/authApi';
 import signInStatusState from '@atoms/signInStatus';
+import Spinner from '@components/common/Spinner';
 import useFetch from '@hooks/useFetch';
+import { FlexColumnCenter, FullPageWrapper } from '@styles/layout';
 import { toastError } from '@utils/toast';
 
 export default function Github() {
   const router = useRouter();
-  const { data: user, execute: githubSignIn } = useFetch(githubSignInApi);
+
   const setSignInStatus = useSetRecoilState(signInStatusState);
+  const { data: user, execute: githubSignIn } = useFetch(githubSignInApi);
 
   useEffect(() => {
     if (router.query.error) {
-      toastError('깃헙 로그인 과정에서 에러가 발생했습니다.');
+      toastError('GitHub 로그인에 실패했습니다.');
+
       router.push('/');
     }
   }, [router.query.error]);
 
   useEffect(() => {
-    if (router.query.code) {
-      githubSignIn({
-        code: router.query.code,
-      });
-    }
+    if (router.query.code) githubSignIn({ code: router.query.code });
   }, [router.query.code]);
 
   useEffect(() => {
     if (!user) return;
 
-    setSignInStatus({
-      ...user,
-    });
+    setSignInStatus({ ...user });
+
     router.push('/');
   }, [user]);
 
-  return <div>Github 로그인 시동 중입니다.....</div>;
+  return (
+    <FullPageWrapper>
+      <FlexColumnCenter style={{ height: '100%', backgroundColor: 'var(--light-yellow-color)' }}>
+        <Spinner style={{ width: 100, height: 100, borderWidth: 16 }} />
+        <div style={{ marginTop: '32px' }}>Github 로그인 중 입니다.</div>
+      </FlexColumnCenter>
+    </FullPageWrapper>
+  );
 }

--- a/frontend/pages/github.tsx
+++ b/frontend/pages/github.tsx
@@ -41,7 +41,7 @@ export default function Github() {
     <FullPageWrapper>
       <FlexColumnCenter style={{ height: '100%', backgroundColor: 'var(--light-yellow-color)' }}>
         <Spinner style={{ width: 100, height: 100, borderWidth: 16 }} />
-        <div style={{ marginTop: '32px' }}>Github 로그인 중 입니다.</div>
+        <div style={{ marginTop: '32px' }}>GitHub 로그인 중 입니다.</div>
       </FlexColumnCenter>
     </FullPageWrapper>
   );

--- a/frontend/styles/layout.ts
+++ b/frontend/styles/layout.ts
@@ -1,28 +1,35 @@
 import styled from 'styled-components';
 
-export const FlexCenter = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
 export const Flex = styled.div`
   display: flex;
 `;
 
-export const FlexColumn = styled.div`
-  display: flex;
+export const FlexCenter = styled(Flex)`
+  justify-content: center;
+  align-items: center;
+`;
+
+export const FlexColumn = styled(Flex)`
   flex-direction: column;
 `;
 
-export const FlexSpaceBetween = styled.div`
+export const FlexSpaceBetween = styled(Flex)`
   display: flex;
   justify-content: space-between;
 `;
 
-export const FlexColumnCenter = styled.div`
-  display: flex;
-  flex-direction: column;
+export const FlexColumnCenter = styled(FlexColumn)`
+  justify-content: center;
   align-items: center;
+`;
+
+export const FlexColumnAlignCenter = styled(FlexColumn)`
+  align-items: center;
+`;
+
+export const FullPageWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
 `;
 
 export const PageWrapper = styled.div`
@@ -31,12 +38,12 @@ export const PageWrapper = styled.div`
   background-color: var(--light-yellow-color);
 `;
 
-export const PageInnerSmall = styled(FlexColumnCenter)`
+export const PageInnerSmall = styled(FlexColumnAlignCenter)`
   margin: 0 auto;
   max-width: 900px;
 `;
 
-export const PageInnerLarge = styled(FlexColumnCenter)`
+export const PageInnerLarge = styled(FlexColumnAlignCenter)`
   margin: 0 auto;
   max-width: 1200px;
 `;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,6 +26,6 @@
       "@interfaces": ["./interfaces"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "components/study/BookListTab"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 개요

GitHub 로그인 대기 페이지 UI/UX를 개선하고, Spinner 컴포넌트를 추가했습니다.

## 변경 사항

- GitHub 로그인 대기 페이지 UI/UX 개선
- Spinner 컴포넌트 추가
- layout 스타일 개선

## 참고 사항

- 새롭게 추가된 Spinner 컴포넌트는 다음과 같은 방법으로 사용하시면 됩니다.

```ts
<Spinner style={{ width: 100, height: 100, borderWidth: 16 }} />
```

## 스크린샷

https://user-images.githubusercontent.com/26927792/206223066-d6ad639b-e625-4f23-8f32-dbfebdf35292.mov

## 관련 이슈

- #221 
