### PR TITLE
에디터 페이지 반응형 작업

### DIFF
--- a/frontend/components/edit/Editor/styled.ts
+++ b/frontend/components/edit/Editor/styled.ts
@@ -15,6 +15,12 @@ export const EditorInner = styled.div`
   overflow: auto;
   padding: 32px;
   position: relative;
+
+  @media ${(props) => props.theme.tablet} {
+    &:nth-child(2) {
+      display: none;
+    }
+  }
 `;
 
 export const CodeMirrorWrapper = styled.div`


### PR DESCRIPTION
## 개요

에디터 페이지 반응형 작업을 진행했습니다.

## 변경 사항

- 에디터 페이지가 타블렛 최대 너비(992px)보다 작은 경우 미리보기가 표시되지 않도록 변경

## 스크린샷

**너비가 992px 보다 큰 경우**

![스크린샷 2022-12-08 14 06 29](https://user-images.githubusercontent.com/26927792/206361446-3393b0e4-b5b5-4935-ad3b-19c5157d48f6.png)

**너비가 992px 보다 작은 경우**

![스크린샷 2022-12-08 14 06 46](https://user-images.githubusercontent.com/26927792/206361463-a9598a28-4bae-4b86-98fd-63486c54e077.png)

## 관련 이슈

- #242 
