### PR TITLE
뷰어페이지 북마크 상태 반영 안 되는 버그 수정

### DIFF
--- a/frontend/pages/viewer/[...data].tsx
+++ b/frontend/pages/viewer/[...data].tsx
@@ -20,12 +20,12 @@ import { IArticleBook, IBookScraps } from '@interfaces';
 import { Flex } from '@styles/layout';
 
 interface ViewerProps {
-  book: IBookScraps;
   article: IArticleBook;
 }
 
-export default function Viewer({ book, article }: ViewerProps) {
+export default function Viewer({ article }: ViewerProps) {
   const { data: userBooks, execute: getUserKnottedBooks } = useFetch(getUserKnottedBooksApi);
+  const { data: book, execute: getBook } = useFetch<IBookScraps>(getBookApi);
 
   const user = useRecoilValue(signInStatusState);
   const router = useRouter();
@@ -45,23 +45,32 @@ export default function Viewer({ book, article }: ViewerProps) {
     getUserKnottedBooks(user.nickname);
   }, [user.nickname]);
 
-  const checkArticleAuthority = (id: number) => {
-    if (book.scraps.find((scrap) => scrap.article.id === id)) {
+  const checkArticleAuthority = (targetBook: IBookScraps, id: number) => {
+    if (targetBook.scraps.find((scrap) => scrap.article.id === id)) {
       return true;
     }
     return false;
   };
 
   useEffect(() => {
-    if (!checkArticleAuthority(article.id)) router.push('/404');
-  });
+    if (Array.isArray(router.query.data) && router.query.data?.length === 2) {
+      const bookId = router.query.data[0];
+      getBook(bookId);
+    }
+  }, [router.query.data]);
+
+  useEffect(() => {
+    if (!book) return;
+    if (!checkArticleAuthority(book, article.id)) router.push('/404');
+  }, [book]);
+
   useEffect(() => {
     if (window.innerWidth > 576) setIsOpened(true);
   }, []);
 
   return (
     <>
-      <ViewerHead articleTitle={article.title} articleContent={article.content} />
+      {article && <ViewerHead articleTitle={article.title} articleContent={article.content} />}
       <GNB />
       {book && article ? (
         <Flex>
@@ -96,8 +105,7 @@ export default function Viewer({ book, article }: ViewerProps) {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const [bookId, articleId] = context.query.data as string[];
-  const book = await getBookApi(bookId);
   const article = await getArticleApi(articleId);
 
-  return { props: { book, article } };
+  return { props: { article } };
 };


### PR DESCRIPTION
## 개요

뷰어페이지에서 북마크 상태가 반영되지 않는 버그를 수정하였습니다.

## 변경 사항

뷰어페이지에서 article & book 모두를 SSR로 받아오는 것에서, **article만 SSR로 받아오는 것으로 변경**했습니다.

book을 받아올 때 유저의 토큰을 확인하여 bookmark id를 받아오기 때문에, SSR로 받아오면 토큰이 없어서 항상 bookmark id가 없게 됩니다. 
현재 뷰어페이지의 메타 태그는 전부 article 정보만 사용하고 있어서 book과 관련된 데이터는 SEO에 영향이 없기에 book은 SSR에서 다시 CSR로 변경되어도 된다고 판단하여 수정하였습니다.