### PR TITLE
글 검색 결과에 HTML 태그가 들어있는 오류 수정 작업

### DIFF
--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -139,7 +139,10 @@ export default function Search() {
       return {
         ...article,
         title: highlightWord(article.title, keywords),
-        content: highlightWord(article.content, keywords),
+        content: highlightWord(
+          article.content.slice(0, 400).replace(/(<([^>]+)>)/gi, ''),
+          keywords
+        ),
       };
     });
 


### PR DESCRIPTION
## 개요

글 검색 결과에 HTML 태그가 들어있는 오류를 수정했습니다.

## 변경 사항

- 글 검색 결과에서 HTML 태그가 보이는 부분을 정규식으로 제거

## 스크린샷

<img width="954" alt="image" src="https://user-images.githubusercontent.com/26927792/206693411-361cd445-24c5-485e-9b0d-ceafbf378b3f.png">

## 관련 이슈

- #271 
