### PR TITLE
검색 결과 책 표시 오류 및 뷰어페이지 이중스크롤 버그 해결

### DIFF
--- a/frontend/components/common/Book/index.tsx
+++ b/frontend/components/common/Book/index.tsx
@@ -38,7 +38,7 @@ export default function Book({ book }: BookProps) {
     // 수정모드일때만 아래 onclick이 실행되도록 수정해야함 -> 민형님 작업 후
     <BookWrapper>
       <BookLink
-        isArticleExists={!!scraps[0]}
+        isarticleexists={scraps[0] ? 'true' : 'false'}
         href={scraps[0] ? `/viewer/${id}/${scraps[0].article.id}` : ``}
       >
         <BookThumbnail
@@ -53,7 +53,7 @@ export default function Book({ book }: BookProps) {
         <FlexSpaceBetween>
           <BookTitle>
             <BookLink
-              isArticleExists={!!scraps[0]}
+              isarticleexists={scraps[0] ? 'true' : 'false'}
               href={scraps[0] ? `/viewer/${id}/${scraps[0].article.id}` : ``}
             >
               <TextLarge>{title}</TextLarge>

--- a/frontend/components/common/Book/styled.ts
+++ b/frontend/components/common/Book/styled.ts
@@ -112,7 +112,7 @@ export const AuthorLink = styled(Link)`
   margin-top: 2px;
 `;
 
-export const BookLink = styled(Link)<{ isArticleExists: boolean }>`
+export const BookLink = styled(Link)<{ isarticleexists: string }>`
   text-decoration: none;
-  ${(props) => (props.isArticleExists ? '' : 'pointer-events: none;')}
+  ${(props) => (props.isarticleexists === 'true' ? '' : 'pointer-events: none;')}
 `;

--- a/frontend/components/edit/Editor/styled.ts
+++ b/frontend/components/edit/Editor/styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const EditorWrapper = styled.div`
   width: 100%;
-  height: 100vh;
+  height: calc(var(--window-inner-height));
   display: flex;
 
   > div:nth-child(2) {
@@ -25,7 +25,7 @@ export const EditorInner = styled.div`
 
 export const CodeMirrorWrapper = styled.div`
   font-size: 16px;
-  height: calc(100vh - 160px);
+  height: calc(var(--window-inner-height) - 160px);
   overflow: auto;
 
   .cm-editor.cm-focused {

--- a/frontend/components/viewer/ArticleContent/styled.ts
+++ b/frontend/components/viewer/ArticleContent/styled.ts
@@ -4,7 +4,7 @@ import { Flex, FlexColumn } from '@styles/layout';
 
 export const ArticleContainer = styled(Flex)`
   flex: 1;
-  height: calc(100vh - 67px);
+  height: calc(var(--window-inner-height) - 67px);
 `;
 export const ArticleLeftBtn = styled.div`
   position: fixed;
@@ -57,6 +57,7 @@ export const ArticleTitleBtnBox = styled(Flex)`
   margin-top: 16px;
   border-top: 1px solid var(--grey-02-color);
   padding-top: 10px;
+  margin-bottom: 30px;
 `;
 export const ArticleContents = styled.div`
   margin-top: 20px;

--- a/frontend/components/viewer/ClosedSideBar/styled.ts
+++ b/frontend/components/viewer/ClosedSideBar/styled.ts
@@ -4,7 +4,7 @@ import { FlexCenter } from '@styles/layout';
 
 export const ClosedSideBarWrapper = styled.div`
   min-width: 30px;
-  height: calc(100vh - 67px);
+  height: calc(var(--window-inner-height) - 67px);
   background-color: var(--primary-color);
 `;
 

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -17,7 +17,7 @@ const slide = keyframes`
 export const TocWrapper = styled(Flex)`
   /* 고정크기? %? */
   flex-basis: 300px;
-  height: calc(100vh - 67px);
+  height: calc(var(--window-inner-height) - 67px);
   overflow: hidden;
   background-color: var(--primary-color);
   color: var(--white-color);

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -52,7 +52,7 @@ export const TocContainer = styled.div`
   padding: 24px;
   margin-top: 10px;
   overflow: auto;
-  height: calc(100vh - 357px);
+  height: calc(var(--window-inner-height) - 357px);
 
   ::-webkit-scrollbar {
     width: 10px;

--- a/frontend/pages/editor.tsx
+++ b/frontend/pages/editor.tsx
@@ -14,6 +14,7 @@ import ModifyModal from '@components/edit/ModifyModal';
 import PublishModal from '@components/edit/PublishModal';
 import useFetch from '@hooks/useFetch';
 import { IArticle } from '@interfaces';
+import { PageNoScrollWrapper } from '@styles/layout';
 import { toastError } from '@utils/toast';
 
 export default function EditorPage() {
@@ -49,8 +50,18 @@ export default function EditorPage() {
     setOriginalArticle(article);
   }, [article]);
 
+  const syncHeight = () => {
+    document.documentElement.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
+  };
+
+  useEffect(() => {
+    syncHeight();
+    window.addEventListener('resize', syncHeight);
+    return () => window.removeEventListener('resize', syncHeight);
+  }, []);
+
   return (
-    <>
+    <PageNoScrollWrapper>
       <EditHead />
       <Editor handleModalOpen={handleModalOpen} originalArticle={originalArticle} />
 
@@ -64,6 +75,6 @@ export default function EditorPage() {
             <PublishModal books={books} />
           </Modal>
         ))}
-    </>
+    </PageNoScrollWrapper>
   );
 }

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -173,7 +173,7 @@ export default function Search() {
     });
 
     if (bookPage.pageNumber === 2) setBooks(newBooksHighlighted);
-    setBooks(books.concat(newBooksHighlighted));
+    else setBooks(books.concat(newBooksHighlighted));
 
     setBookPage({
       ...bookPage,

--- a/frontend/pages/viewer/[...data].tsx
+++ b/frontend/pages/viewer/[...data].tsx
@@ -17,7 +17,7 @@ import TOC from '@components/viewer/TOC';
 import ViewerHead from '@components/viewer/ViewerHead';
 import useFetch from '@hooks/useFetch';
 import { IArticleBook, IBookScraps } from '@interfaces';
-import { Flex } from '@styles/layout';
+import { Flex, PageNoScrollWrapper } from '@styles/layout';
 
 interface ViewerProps {
   book: IBookScraps;
@@ -68,7 +68,7 @@ export default function Viewer({ book, article }: ViewerProps) {
   }, []);
 
   return (
-    <>
+    <PageNoScrollWrapper>
       <ViewerHead articleTitle={article.title} articleContent={article.content} />
       <GNB />
       {book && article ? (
@@ -98,7 +98,7 @@ export default function Viewer({ book, article }: ViewerProps) {
           <ScrapModal books={userBooks} handleModalClose={handleModalClose} article={article} />
         </Modal>
       )}
-    </>
+    </PageNoScrollWrapper>
   );
 }
 

--- a/frontend/pages/viewer/[...data].tsx
+++ b/frontend/pages/viewer/[...data].tsx
@@ -55,8 +55,16 @@ export default function Viewer({ book, article }: ViewerProps) {
   useEffect(() => {
     if (!checkArticleAuthority(article.id)) router.push('/404');
   });
+
+  const syncHeight = () => {
+    document.documentElement.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
+  };
+
   useEffect(() => {
     if (window.innerWidth > 576) setIsOpened(true);
+    syncHeight();
+    window.addEventListener('resize', syncHeight);
+    return () => window.removeEventListener('resize', syncHeight);
   }, []);
 
   return (

--- a/frontend/styles/layout.ts
+++ b/frontend/styles/layout.ts
@@ -52,3 +52,10 @@ export const PageInnerLarge = styled(FlexColumnAlignCenter)`
 export const TopBar = styled.nav`
   height: 67px;
 `;
+
+export const PageNoScrollWrapper = styled.div`
+  overflow: hidden;
+  position: fixed;
+  top: 0px;
+  width: 100%;
+`;


### PR DESCRIPTION
## 개요

검색 결과 책 표시 오류 및 뷰어페이지 이중스크롤 버그를 해결하였습니다.

## 변경 사항

- 검색 결과 책이 append 돼서 나타나는 오류는 제가 else를 빼먹어서 발생한 버그였습니다... 로직은 글 결과 표시와 동일합니다.
- Booklink props 명칭을 소문자로 변경하였습니다. 
- **사파리 환경에서 뷰어페이지 및 에디터 페이지에서 이중스크롤이 생기는 문제를 해결하였는데, 크롬으로 테스트하기가 쉽지 않아 완전히 해결된 것인지는 배포 환경에서 다시 확인해봐야될 것 같습니다**. 
   스타일링할 때 화면에 꽉차게 하기 위해 height: 100vh 값을 여러 군데에서 사용하고 있었는데, 사파리에서는 페이지 아래 바가 차지하는 자리까지 100vh로 계산되어서, 바에 버튼이 가려져서 생긴 문제였습니다. 아래 참고링크 통해서 해결해보았습니다.


## 참고 사항

참고자료 링크입니다.
- [Error | 모바일 브라우저에서 100vh 적용 오류 해결 (ios/android)](https://velog.io/@edie_ko/Tip-%EB%AA%A8%EB%B0%94%EC%9D%BC-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-100vh-%EC%A0%81%EC%9A%A9-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0-iosandroid)
- [100vh problem in safari](https://medium.com/quick-code/100vh-problem-with-ios-safari-92ab23c852a8)


## 관련 이슈

- #267 
- #269 
