### PR TITLE
에디터 리스트 태그 줄바꿈 오류 수정 작업

### DIFF
--- a/frontend/components/common/Content/styled.ts
+++ b/frontend/components/common/Content/styled.ts
@@ -42,12 +42,10 @@ export const ContentBody = styled.div`
 
   ol {
     list-style-type: decimal;
-    list-style-position: inside;
   }
 
   ul {
     list-style-type: disc;
-    list-style-position: inside;
   }
 
   p {


### PR DESCRIPTION
## 개요

에디터 리스트 태그 내부에서 줄바꿈이 생기는 오류를 수정했습니다.

## 변경 사항

- Content 컴포넌트 스타일 수정

## 참고 사항

- p 태그가 들어가서 발생한 문제가 아니었고, `list-style-position`이 지정되어 있어서 생기는 문제였습니다.

## 스크린샷

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26927792/206703679-0bbee5a7-de6d-480e-9804-a214fedf318b.png">

## 관련 이슈

- #101 
