### PR TITLE
글 검색 시 글 내용에 검색어가 나타나도록 문자열 파싱 작업

### DIFF
--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -142,18 +142,15 @@ export default function Search() {
     setIsArticleNoResult(false);
 
     const newArticlesHighlighted = newArticles.data.map((article: IArticle) => {
-      const keywords = debouncedKeyword.trim().split(' ');
+      const keywords = debouncedKeyword
+        .trim()
+        .split(' ')
+        .filter((word: string) => word);
 
       return {
         ...article,
         title: highlightWord(article.title, keywords),
-        content: highlightWord(
-          // article.content.replace(/(<([^>]+)>)/gi, ''),
-          // article.content.slice(0, 400).replace(/(<([^>]+)>)/gi, ''),
-          article.content,
-          keywords,
-          true
-        ),
+        content: highlightWord(article.content, keywords, true),
       };
     });
 
@@ -178,7 +175,10 @@ export default function Search() {
     setIsBookNoResult(false);
 
     const newBooksHighlighted = newBooks.data.map((book: IBook) => {
-      const keywords = debouncedKeyword.trim().split(' ');
+      const keywords = debouncedKeyword
+        .trim()
+        .split(' ')
+        .filter((word: string) => word);
 
       return {
         ...book,

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -37,7 +37,7 @@ export default function Search() {
   const [isArticleNoResult, setIsArticleNoResult] = useState(false);
   const [isBookNoResult, setIsBookNoResult] = useState(false);
 
-  const highlightWord = (text: string, words: string[]): React.ReactNode => {
+  const highlightWord = (text: string, words: string[], isFirst = false): React.ReactNode => {
     let wordIndexList = words.map((word) => text.toLowerCase().indexOf(word.toLowerCase()));
 
     const filteredWords = words.filter((_, index) => wordIndexList[index] !== -1);
@@ -51,11 +51,19 @@ export default function Search() {
 
     const endIndex = startIndex + targetWord.length;
 
+    let paddingIndex = 0;
+
+    if (isFirst) {
+      const regex = /(<([^>]+)>)/g;
+
+      while (regex.test(text.slice(0, startIndex))) paddingIndex = regex.lastIndex;
+    }
+
     return (
       <>
-        {text.slice(0, startIndex)}
+        {text.slice(paddingIndex, startIndex)}
         <b>{text.slice(startIndex, endIndex)}</b>
-        {highlightWord(text.slice(endIndex), words)}
+        {highlightWord(text.slice(endIndex).replace(/(<([^>]+)>)/gi, ''), words)}
       </>
     );
   };
@@ -140,8 +148,11 @@ export default function Search() {
         ...article,
         title: highlightWord(article.title, keywords),
         content: highlightWord(
-          article.content.slice(0, 400).replace(/(<([^>]+)>)/gi, ''),
-          keywords
+          // article.content.replace(/(<([^>]+)>)/gi, ''),
+          // article.content.slice(0, 400).replace(/(<([^>]+)>)/gi, ''),
+          article.content,
+          keywords,
+          true
         ),
       };
     });


### PR DESCRIPTION
## 개요

검색된 글의 내용에서 검색어가 최대한 나타날 수 있도록 문자열 파싱 작업을 진행했습니다.

## 변경 사항

- 검색된 글 내용 파싱 로직 추가
- 공백으로 분리된 검색 키워드 추출 로직 수정

## 참고 사항

- 

## 스크린샷

**변경 전**

<img width="1440" alt="스크린샷 2022-12-10 11 58 55" src="https://user-images.githubusercontent.com/26927792/206825601-4dd7b857-4daf-489f-b95d-45b0fd976e16.png">

**변경 후**

<img width="1440" alt="스크린샷 2022-12-10 11 58 35" src="https://user-images.githubusercontent.com/26927792/206825591-25ddbdf9-b915-4f62-bab9-4f9595de3634.png">

## 관련 이슈

- #164 
