### PR TITLE
구글 검색봇 Ping 요청 스케줄러 작업

### DIFF
--- a/.github/workflows/sitemap-ping.yml
+++ b/.github/workflows/sitemap-ping.yml
@@ -1,0 +1,15 @@
+name: Sitemap Ping Schedule
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  cron:
+    name: Cron
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+        curl https://www.google.com/ping\?sitemap\=https://www.knoticle.app/sitemap.xml


### PR DESCRIPTION
## 개요

매일 자정에 구글에 저희 sitemap.xml을 읽도록 핑을 보내는 스케줄러를 추가했습니다.

## 변경 사항

- GitHub Action 스케줄러 추가

## 스크린샷

![스크린샷 2022-12-10 12 08 15](https://user-images.githubusercontent.com/26927792/206826674-bbd5f701-eef5-4027-bb73-618c8943d572.png)

## 관련 이슈

- #245 
