### PR TITLE
클라이언트 책 생성, 수정 시 빈 제목 방지

### DIFF
--- a/frontend/components/study/AddBook/index.tsx
+++ b/frontend/components/study/AddBook/index.tsx
@@ -10,7 +10,7 @@ import Button from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
 import { FlexSpaceBetween } from '@styles/layout';
-import { toastSuccess } from '@utils/toast';
+import { toastError, toastSuccess } from '@utils/toast';
 
 import {
   BookWrapper,
@@ -43,6 +43,11 @@ export default function AddBook({ handleModalClose }: AddBookProps) {
   }, [addBookData]);
 
   const handleAddBookBtnClick = () => {
+    if (title.value === '') {
+      toastError('책 제목이 비어있습니다.');
+      return;
+    }
+
     addBook({ title: title.value });
   };
   return (

--- a/frontend/components/study/EditBookModal/index.tsx
+++ b/frontend/components/study/EditBookModal/index.tsx
@@ -15,6 +15,7 @@ import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
 import { IBookScraps } from '@interfaces';
 import { FlexSpaceBetween } from '@styles/layout';
+import { toastError } from '@utils/toast';
 
 import {
   BookWrapper,
@@ -70,6 +71,11 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
   };
 
   const handleCompletedBtnClick = () => {
+    if (titleData === '') {
+      toastError('책 제목이 비어있습니다.');
+      return;
+    }
+
     const editScraps = scrapList.map((v, i) => ({ ...v, order: i + 1 }));
 
     // 해당하는 책을 찾아서 전역에서 관리하고 있는 애를 변경해서 업데이트


### PR DESCRIPTION
## 개요

- #278 
도현님이 위 작업에서 서버 단에서 빈 글과 책 제목 방지를 해주셨고 주말 회의에서 
일단 다른 부분은 현행 유지하되 클라이언트 단에서 막아주는 로직 추가하는 걸로 결정된 사항 반영

## 변경 사항

- 책 생성 시 빈 제목 클라이언트 단에서 먼저 방지
- 책 수정 시 빈 제목 클라이언트 단에서 먼저 방지


## 스크린샷

![image](https://user-images.githubusercontent.com/67371123/206893586-db4e4b92-64ba-4e07-a42b-0705ae99df6e.png)


## 관련 이슈

- closes #257 
