### PR TITLE
슬라이더 반응형 변경 시 위치 조정

### DIFF
--- a/frontend/components/home/Slider/index.tsx
+++ b/frontend/components/home/Slider/index.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import LeftArrowIcon from '@assets/ico_arrow_left.svg';
 import RightArrowIcon from '@assets/ico_arrow_right.svg';
@@ -30,6 +30,12 @@ interface SliderProps {
   numberPerPage: number;
 }
 
+const setNumBetween = (val: number, min: number, max: number) => {
+  if (val < min) return min;
+  if (val > max) return max;
+  return val;
+};
+
 function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
   const [curBookIndex, setCurBookIndex] = useState(0);
   const [sliderNumber, setSliderNumber] = useState(1);
@@ -40,13 +46,23 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
   const sliderIndicatorNumbersList = Array.from({ length: sliderIndicatorCount }, (_, i) => i + 1);
 
   const handleLeftArrowClick = () => {
-    setCurBookIndex(curBookIndex - numberPerPage);
-    setSliderNumber(sliderNumber - 1);
+    setCurBookIndex(setNumBetween(curBookIndex - numberPerPage, 0, bookList.length - 1));
+    setSliderNumber(setNumBetween(sliderNumber - 1, 1, sliderIndicatorCount));
   };
+
   const handleRightArrowClick = () => {
-    setCurBookIndex(curBookIndex + numberPerPage);
-    setSliderNumber(sliderNumber + 1);
+    setCurBookIndex(setNumBetween(curBookIndex + numberPerPage, 0, bookList.length - 1));
+    setSliderNumber(setNumBetween(sliderNumber + 1, 1, sliderIndicatorCount));
   };
+
+  useEffect(() => {
+    if (!bookList) return;
+
+    const newSliderNum = Math.round(curBookIndex / numberPerPage) + 1;
+
+    setSliderNumber(setNumBetween(newSliderNum, 1, sliderIndicatorCount));
+    setCurBookIndex(setNumBetween((newSliderNum - 1) * numberPerPage, 0, bookList.length - 1));
+  }, [numberPerPage]);
 
   return (
     <SliderWrapper>

--- a/frontend/components/home/Slider/index.tsx
+++ b/frontend/components/home/Slider/index.tsx
@@ -58,10 +58,14 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
   useEffect(() => {
     if (!bookList) return;
 
-    const newSliderNum = Math.round(curBookIndex / numberPerPage) + 1;
-
-    setSliderNumber(setNumBetween(newSliderNum, 1, sliderIndicatorCount));
-    setCurBookIndex(setNumBetween((newSliderNum - 1) * numberPerPage, 0, bookList.length - 1));
+    const newSliderNum = setNumBetween(
+      Math.round(curBookIndex / numberPerPage) + 1,
+      1,
+      sliderIndicatorCount
+    );
+    // console.log(newSliderNum, 1, sliderIndicatorCount);
+    setSliderNumber(newSliderNum);
+    setCurBookIndex((newSliderNum - 1) * numberPerPage);
   }, [numberPerPage]);
 
   return (

--- a/frontend/components/home/Slider/index.tsx
+++ b/frontend/components/home/Slider/index.tsx
@@ -46,13 +46,13 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
   const sliderIndicatorNumbersList = Array.from({ length: sliderIndicatorCount }, (_, i) => i + 1);
 
   const handleLeftArrowClick = () => {
-    setCurBookIndex(setNumBetween(curBookIndex - numberPerPage, 0, bookList.length - 1));
-    setSliderNumber(setNumBetween(sliderNumber - 1, 1, sliderIndicatorCount));
+    setCurBookIndex(curBookIndex - numberPerPage);
+    setSliderNumber(sliderNumber - 1);
   };
 
   const handleRightArrowClick = () => {
-    setCurBookIndex(setNumBetween(curBookIndex + numberPerPage, 0, bookList.length - 1));
-    setSliderNumber(setNumBetween(sliderNumber + 1, 1, sliderIndicatorCount));
+    setCurBookIndex(curBookIndex + numberPerPage);
+    setSliderNumber(sliderNumber + 1);
   };
 
   useEffect(() => {
@@ -63,7 +63,7 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
       1,
       sliderIndicatorCount
     );
-    // console.log(newSliderNum, 1, sliderIndicatorCount);
+
     setSliderNumber(newSliderNum);
     setCurBookIndex((newSliderNum - 1) * numberPerPage);
   }, [numberPerPage]);


### PR DESCRIPTION
## 개요

슬아이더가 반응형으로 변경 될 시에 위치 인덱스 값이 꼬이는 에러가 있었는데 이를 해결함

## 변경 사항

- 현재 보여줘야 하는 책 개수가 변경됨에 따라서 해당하는 위치값을 재조정하는 로직 추가

## 참고 사항

- 현재 책 인덱스를 변경된 보여져야 하는 책 개수로 나눈 몫을 반올림한 페이지로 재조정하는 방식으로 구현

## 스크린샷

gif 크기가 커져서 슬랙에서 공유,,

## 관련 이슈

- closes #236 
