### PR TITLE
검색페이지 검색 결과 및 스크롤 보존 작업

### DIFF
--- a/frontend/components/search/ArticleItem/index.tsx
+++ b/frontend/components/search/ArticleItem/index.tsx
@@ -15,8 +15,8 @@ import {
 } from './styled';
 
 interface ArticleItemProps {
-  title: string;
-  content: string;
+  title: React.ReactNode;
+  content: React.ReactNode;
   nickname: string;
   articleUrl: string;
   studyUrl: string;

--- a/frontend/components/search/ArticleList/index.tsx
+++ b/frontend/components/search/ArticleList/index.tsx
@@ -3,16 +3,48 @@ import { IArticleBook } from '@interfaces';
 
 interface ArticleListProps {
   articles: IArticleBook[];
+  keywords: string[];
 }
 
-export default function ArticleList({ articles }: ArticleListProps) {
+export default function ArticleList({ articles, keywords }: ArticleListProps) {
+  const highlightWord = (text: string, words: string[], isFirst = false): React.ReactNode => {
+    let wordIndexList = words.map((word) => text.toLowerCase().indexOf(word.toLowerCase()));
+
+    const filteredWords = words.filter((_, index) => wordIndexList[index] !== -1);
+    wordIndexList = wordIndexList.filter((wordIndex) => wordIndex !== -1);
+
+    if (wordIndexList.length === 0) return text;
+
+    const startIndex = Math.min(...wordIndexList);
+
+    const targetWord = filteredWords[wordIndexList.indexOf(startIndex)];
+
+    const endIndex = startIndex + targetWord.length;
+
+    let paddingIndex = 0;
+
+    if (isFirst) {
+      const regex = /(<([^>]+)>)/g;
+
+      while (regex.test(text.slice(0, startIndex))) paddingIndex = regex.lastIndex;
+    }
+
+    return (
+      <>
+        {text.slice(paddingIndex, startIndex)}
+        <b>{text.slice(startIndex, endIndex)}</b>
+        {highlightWord(text.slice(endIndex).replace(/(<([^>]+)>)/gi, ''), words)}
+      </>
+    );
+  };
+
   return (
     <>
       {articles.map((article) => (
         <ArticleItem
           key={article.id}
-          title={article.title}
-          content={article.content}
+          title={highlightWord(article.title, keywords)}
+          content={highlightWord(article.content, keywords, true)}
           nickname={article.book.user.nickname}
           articleUrl={`/viewer/${article.book.id}/${article.id}`}
           studyUrl={`/study/${article.book.user.nickname}`}

--- a/frontend/components/search/BookList/index.tsx
+++ b/frontend/components/search/BookList/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import Book from '@components/common/Book';
 import { IBookScraps } from '@interfaces';
 
@@ -5,12 +7,61 @@ import { BookContainer, BookListWrapper } from './styled';
 
 interface BookListProps {
   books: IBookScraps[];
+  keywords: string[];
 }
 
-export default function BookList({ books }: BookListProps) {
+interface HighlightedBooks extends Omit<IBookScraps, 'title'> {
+  title: string | React.ReactNode;
+}
+
+export default function BookList({ books, keywords }: BookListProps) {
+  const [highlightedBooks, setHighlightedBooks] = useState<HighlightedBooks[]>([]);
+
+  const highlightWord = (text: string, words: string[], isFirst = false): React.ReactNode => {
+    let wordIndexList = words.map((word) => text.toLowerCase().indexOf(word.toLowerCase()));
+
+    const filteredWords = words.filter((_, index) => wordIndexList[index] !== -1);
+    wordIndexList = wordIndexList.filter((wordIndex) => wordIndex !== -1);
+
+    if (wordIndexList.length === 0) return text;
+
+    const startIndex = Math.min(...wordIndexList);
+
+    const targetWord = filteredWords[wordIndexList.indexOf(startIndex)];
+
+    const endIndex = startIndex + targetWord.length;
+
+    let paddingIndex = 0;
+
+    if (isFirst) {
+      const regex = /(<([^>]+)>)/g;
+
+      while (regex.test(text.slice(0, startIndex))) paddingIndex = regex.lastIndex;
+    }
+
+    return (
+      <>
+        {text.slice(paddingIndex, startIndex)}
+        <b>{text.slice(startIndex, endIndex)}</b>
+        {highlightWord(text.slice(endIndex).replace(/(<([^>]+)>)/gi, ''), words)}
+      </>
+    );
+  };
+
+  useEffect(() => {
+    setHighlightedBooks(
+      books.map((book) => {
+        return {
+          ...book,
+          title: highlightWord(book.title, keywords),
+        };
+      })
+    );
+  }, [books, keywords]);
+
   return (
     <BookListWrapper>
-      {books.map((book) => (
+      {highlightedBooks.map((book: any) => (
         <BookContainer key={book.id}>
           <Book key={book.id} book={book} />
         </BookContainer>

--- a/frontend/components/search/SearchFilter/index.tsx
+++ b/frontend/components/search/SearchFilter/index.tsx
@@ -4,11 +4,17 @@ import signInStatusState from '@atoms/signInStatus';
 
 import { FilterButton, FilterGroup, FilterLabel, FilterWrapper } from './styled';
 
-interface SearchFilterProps {
-  handleFilter: (value: { [value: string]: string | number }) => void;
+interface Filter {
+  type: string;
+  userId: number;
 }
 
-export default function SearchFilter({ handleFilter }: SearchFilterProps) {
+interface SearchFilterProps {
+  handleFilter: (value: { [value: string]: string | number }) => void;
+  filter: Filter;
+}
+
+export default function SearchFilter({ handleFilter, filter }: SearchFilterProps) {
   const signInStatus = useRecoilValue(signInStatusState);
 
   return (
@@ -19,12 +25,17 @@ export default function SearchFilter({ handleFilter }: SearchFilterProps) {
             type="radio"
             name="type"
             onChange={() => handleFilter({ type: 'article' })}
-            defaultChecked
+            checked={filter.type !== 'book'}
           />
           글
         </FilterLabel>
         <FilterLabel>
-          <FilterButton type="radio" name="type" onChange={() => handleFilter({ type: 'book' })} />
+          <FilterButton
+            type="radio"
+            name="type"
+            onChange={() => handleFilter({ type: 'book' })}
+            checked={filter.type === 'book'}
+          />
           책
         </FilterLabel>
       </FilterGroup>
@@ -33,6 +44,7 @@ export default function SearchFilter({ handleFilter }: SearchFilterProps) {
           <FilterButton
             type="checkbox"
             onChange={(e) => handleFilter({ userId: e.target.checked ? signInStatus.id : 0 })}
+            checked={filter.userId !== 0}
           />
           내 책에서 검색
         </FilterLabel>

--- a/frontend/hooks/useSessionStorage.ts
+++ b/frontend/hooks/useSessionStorage.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+const useSessionStorage = <T>(key: string, initialValue: T) => {
+  const [value, setStateValue] = useState<T>(initialValue);
+  const [isValueSet, setIsValueSet] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setIsValueSet(true);
+      const savedValue = sessionStorage.getItem(key);
+      if (savedValue) setStateValue(JSON.parse(savedValue));
+    }
+  }, [typeof window]);
+
+  const setValue = (newValue: T) => {
+    setStateValue(newValue);
+    sessionStorage.setItem(key, JSON.stringify(newValue));
+  };
+
+  return { value, isValueSet, setValue };
+};
+
+export default useSessionStorage;

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react';
 
 import { searchArticlesApi } from '@apis/articleApi';
 import { searchBooksApi } from '@apis/bookApi';
@@ -11,69 +11,85 @@ import SearchHead from '@components/search/SearchHead';
 import SearchNoResult from '@components/search/SearchNoResult';
 import useDebounce from '@hooks/useDebounce';
 import useFetch from '@hooks/useFetch';
-import useInput from '@hooks/useInput';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import { IArticle, IBook } from '@interfaces';
+import useSessionStorage from '@hooks/useSessionStorage';
 import { PageInnerSmall, PageWrapper } from '@styles/layout';
 
+interface PageInfo {
+  hasNextPage: boolean;
+  pageNumber: number;
+}
+
 export default function Search() {
-  const [articles, setArticles] = useState([]);
-  const [books, setBooks] = useState([]);
+  const { value: articles, setValue: setArticles } = useSessionStorage('articles', []);
+  const { value: books, setValue: setBooks } = useSessionStorage('books', []);
 
   const { data: newArticles, execute: searchArticles } = useFetch(searchArticlesApi);
   const { data: newBooks, execute: searchBooks } = useFetch(searchBooksApi);
 
-  const keyword = useInput();
-  const debouncedKeyword = useDebounce(keyword.value, 300);
+  const {
+    value: filter,
+    isValueSet: isFilterSet,
+    setValue: setFilter,
+  } = useSessionStorage('filter', {
+    type: 'article',
+    userId: 0,
+  });
+
+  const {
+    value: keyword,
+    isValueSet: isKeywordSet,
+    setValue: setKeyword,
+  } = useSessionStorage('keyword', '');
+
+  const debouncedKeyword = useDebounce(keyword, 300);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
   const target = useRef() as RefObject<HTMLDivElement>;
   const isIntersecting = useIntersectionObserver(target);
 
-  const [articlePage, setArticlePage] = useState({ hasNextPage: true, pageNumber: 2 });
-  const [bookPage, setBookPage] = useState({ hasNextPage: true, pageNumber: 2 });
+  const [isInitialRendering, setIsInitialRendering] = useState(true);
 
-  const [filter, setFilter] = useState({ type: 'article', userId: 0 });
+  const { value: articlePage, setValue: setArticlePage } = useSessionStorage<PageInfo>(
+    'articlePage',
+    {
+      hasNextPage: true,
+      pageNumber: 2,
+    }
+  );
+  const { value: bookPage, setValue: setBookPage } = useSessionStorage<PageInfo>('bookPage', {
+    hasNextPage: true,
+    pageNumber: 2,
+  });
 
   const [isArticleNoResult, setIsArticleNoResult] = useState(false);
   const [isBookNoResult, setIsBookNoResult] = useState(false);
 
-  const highlightWord = (text: string, words: string[], isFirst = false): React.ReactNode => {
-    let wordIndexList = words.map((word) => text.toLowerCase().indexOf(word.toLowerCase()));
-
-    const filteredWords = words.filter((_, index) => wordIndexList[index] !== -1);
-    wordIndexList = wordIndexList.filter((wordIndex) => wordIndex !== -1);
-
-    if (wordIndexList.length === 0) return text;
-
-    const startIndex = Math.min(...wordIndexList);
-
-    const targetWord = filteredWords[wordIndexList.indexOf(startIndex)];
-
-    const endIndex = startIndex + targetWord.length;
-
-    let paddingIndex = 0;
-
-    if (isFirst) {
-      const regex = /(<([^>]+)>)/g;
-
-      while (regex.test(text.slice(0, startIndex))) paddingIndex = regex.lastIndex;
-    }
-
-    return (
-      <>
-        {text.slice(paddingIndex, startIndex)}
-        <b>{text.slice(startIndex, endIndex)}</b>
-        {highlightWord(text.slice(endIndex).replace(/(<([^>]+)>)/gi, ''), words)}
-      </>
+  useEffect(() => {
+    setKeywords(
+      debouncedKeyword
+        .trim()
+        .split(' ')
+        .filter((word: string) => word)
     );
-  };
+  }, [debouncedKeyword]);
 
   useEffect(() => {
+    if (!isKeywordSet || !isFilterSet || isInitialRendering) return;
+
     if (debouncedKeyword === '') {
       setArticles([]);
       setBooks([]);
       setIsArticleNoResult(false);
       setIsBookNoResult(false);
+      setArticlePage({
+        hasNextPage: true,
+        pageNumber: 2,
+      });
+      setBookPage({
+        hasNextPage: true,
+        pageNumber: 2,
+      });
       return;
     }
 
@@ -141,21 +157,8 @@ export default function Search() {
 
     setIsArticleNoResult(false);
 
-    const newArticlesHighlighted = newArticles.data.map((article: IArticle) => {
-      const keywords = debouncedKeyword
-        .trim()
-        .split(' ')
-        .filter((word: string) => word);
-
-      return {
-        ...article,
-        title: highlightWord(article.title, keywords),
-        content: highlightWord(article.content, keywords, true),
-      };
-    });
-
-    if (articlePage.pageNumber === 2) setArticles(newArticlesHighlighted);
-    else setArticles(articles.concat(newArticlesHighlighted));
+    if (articlePage.pageNumber === 2) setArticles(newArticles.data);
+    else setArticles(articles.concat(newArticles.data));
 
     setArticlePage({
       ...articlePage,
@@ -174,20 +177,8 @@ export default function Search() {
 
     setIsBookNoResult(false);
 
-    const newBooksHighlighted = newBooks.data.map((book: IBook) => {
-      const keywords = debouncedKeyword
-        .trim()
-        .split(' ')
-        .filter((word: string) => word);
-
-      return {
-        ...book,
-        title: highlightWord(book.title, keywords),
-      };
-    });
-
-    if (bookPage.pageNumber === 2) setBooks(newBooksHighlighted);
-    else setBooks(books.concat(newBooksHighlighted));
+    if (bookPage.pageNumber === 2) setBooks(newBooks.data);
+    else setBooks(books.concat(newBooks.data));
 
     setBookPage({
       ...bookPage,
@@ -202,20 +193,29 @@ export default function Search() {
     });
   };
 
+  const handleKeywordOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsInitialRendering(false);
+    if (e.target) setKeyword(e.target.value);
+  };
+
   return (
     <>
       <SearchHead />
       <GNB />
       <PageWrapper>
         <PageInnerSmall>
-          <SearchBar {...keyword} />
-          <SearchFilter handleFilter={handleFilter} />
+          <SearchBar onChange={handleKeywordOnChange} value={keyword} />
+          <SearchFilter filter={filter} handleFilter={handleFilter} />
           {debouncedKeyword !== '' &&
             filter.type === 'article' &&
-            (isArticleNoResult ? <SearchNoResult /> : <ArticleList articles={articles} />)}
+            (isArticleNoResult ? (
+              <SearchNoResult />
+            ) : (
+              <ArticleList articles={articles} keywords={keywords} />
+            ))}
           {debouncedKeyword !== '' &&
             filter.type === 'book' &&
-            (isBookNoResult ? <SearchNoResult /> : <BookList books={books} />)}
+            (isBookNoResult ? <SearchNoResult /> : <BookList books={books} keywords={keywords} />)}
           <div ref={target} />
         </PageInnerSmall>
       </PageWrapper>

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -15,11 +15,6 @@ import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useSessionStorage from '@hooks/useSessionStorage';
 import { PageInnerSmall, PageWrapperWithHeight } from '@styles/layout';
 
-interface PageInfo {
-  hasNextPage: boolean;
-  pageNumber: number;
-}
-
 export default function Search() {
   const { value: articles, setValue: setArticles } = useSessionStorage('articles', []);
   const { value: books, setValue: setBooks } = useSessionStorage('books', []);
@@ -27,8 +22,14 @@ export default function Search() {
   const { data: newArticles, execute: searchArticles } = useFetch(searchArticlesApi);
   const { data: newBooks, execute: searchBooks } = useFetch(searchBooksApi);
 
-  const { setValue: setScrollTop } = useSessionStorage('scroll', 0);
-  const [initialHeight, setInitialHeight] = useState(0);
+  const { value: articlePage, setValue: setArticlePage } = useSessionStorage('articlePage', {
+    hasNextPage: true,
+    pageNumber: 2,
+  });
+  const { value: bookPage, setValue: setBookPage } = useSessionStorage('bookPage', {
+    hasNextPage: true,
+    pageNumber: 2,
+  });
 
   const {
     value: filter,
@@ -53,20 +54,11 @@ export default function Search() {
 
   const [isInitialRendering, setIsInitialRendering] = useState(true);
 
-  const { value: articlePage, setValue: setArticlePage } = useSessionStorage<PageInfo>(
-    'articlePage',
-    {
-      hasNextPage: true,
-      pageNumber: 2,
-    }
-  );
-  const { value: bookPage, setValue: setBookPage } = useSessionStorage<PageInfo>('bookPage', {
-    hasNextPage: true,
-    pageNumber: 2,
-  });
-
   const [isArticleNoResult, setIsArticleNoResult] = useState(false);
   const [isBookNoResult, setIsBookNoResult] = useState(false);
+
+  const { setValue: setScrollTop } = useSessionStorage('scroll', 0);
+  const [initialHeight, setInitialHeight] = useState(0);
 
   useEffect(() => {
     setKeywords(
@@ -213,6 +205,7 @@ export default function Search() {
       ...filter,
       ...value,
     });
+    if (initialHeight !== 0) setInitialHeight(0);
   };
 
   const handleKeywordOnChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/styles/layout.ts
+++ b/frontend/styles/layout.ts
@@ -72,3 +72,10 @@ export const PageGNBHide = styled.div<{ isscrolldown: 'true' | 'false' }>`
     width: 100%;
   }
 `;
+
+export const PageWrapperWithHeight = styled.div<{ initialHeight: number }>`
+  padding-top: 64px;
+  background-color: var(--light-yellow-color);
+  min-height: ${(props) =>
+    props.initialHeight !== 0 ? `${props.initialHeight + 600}px` : 'calc(100vh - 131px)'};
+`;


### PR DESCRIPTION
## 개요

검색페이지 검색 결과 및 스크롤 보존 작업을 하였습니다.

## 변경 사항

작업 과정은 추후 문서화해서 올리겠습니다.
- 상태를 초기에 sessionStorage에서 불러오고, 상태가 바뀔 때마다 sessionStorage에 값을 업데이트하도록 하는 useSessionStorage 훅을 만들었습니다. sessionStorage에 검색결과, 스크롤 위치 등을 저장하기 위해서입니다.
- 검색 결과, 필터링 정보에 위 훅을 적용했고, 적용 과정에서 highlightWords 함수의 리턴값이 string이 아니라 React.Reactnode인 관계로 에러가 발생하여, articles와 books에는 각각 받아온 데이터를 그대로 저장하고 ArticleList, BookList에서 highlight을 해줘서 렌더링하는 것으로 변경하였습니다.

  highlightWords 함수가 두 군데에서 사용되는데 리턴 값이 React.Reactnode라 utils로 빼기가 어렵더라고요..! 좋은 방법이 있을까요? 

- 스크롤 위치도 마찬가지로 sessionStorage에 저장하고 렌더링 후 보존된 스크롤 위치로 이동하도록 구현했습니다.


## 스크린샷

![chrome-capture-2022-11-12 (1)](https://user-images.githubusercontent.com/109179856/206918266-920de589-5684-457d-9c18-b4b351625417.gif)


## 관련 이슈

- #223 
