### PR TITLE
수정모달, 뷰어페이지 개선 작업, Toast 메세지 추가

### DIFF
--- a/frontend/components/common/Book/styled.ts
+++ b/frontend/components/common/Book/styled.ts
@@ -18,24 +18,24 @@ export const BookWrapper = styled(FlexColumn)`
   overflow: hidden;
 
   color: var(--grey-01-color);
-  aspect-ratio: 280/480;
-  @media ${(props) => props.theme.tablet} {
-    width: 100%;
-    height: auto;
-    overflow: none;
-  }
+  // aspect-ratio: 280/480;
+  // @media ${(props) => props.theme.tablet} {
+  //   width: 100%;
+  //   height: auto;
+  //   overflow: none;
+  // }
 `;
 
 export const BookThumbnail = styled(Image)`
   width: 280px;
   min-height: 200px;
   object-fit: cover;
-  aspect-ratio: 280/200;
+  // aspect-ratio: 280/200;
 
-  @media ${(props) => props.theme.tablet} {
-    width: 100%;
-    min-height: auto;
-  }
+  // @media ${(props) => props.theme.tablet} {
+  //   width: 100%;
+  //   min-height: auto;
+  // }
 `;
 
 export const BookInfoContainer = styled(FlexColumn)`

--- a/frontend/components/edit/ModifyModal/index.tsx
+++ b/frontend/components/edit/ModifyModal/index.tsx
@@ -12,6 +12,7 @@ import Dropdown from '@components/common/Dropdown';
 import ModalButton from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import { IArticle, IBook, IBookScraps, IScrap } from '@interfaces';
+import { toastSuccess } from '@utils/toast';
 
 import { ArticleWrapper, Label, ModifyModalWrapper, WarningLabel } from './styled';
 
@@ -95,7 +96,11 @@ export default function ModifyModal({ books, originalArticle }: ModifyModalProps
   };
 
   useEffect(() => {
-    if (modifiedArticle) router.push('/');
+    if (modifiedArticle) {
+      const { id, title } = modifiedArticle.modifiedArticle;
+      router.push(`/viewer/${selectedBookIndex}/${id}`);
+      toastSuccess(`${title}글이 수정되었습니다.`);
+    }
   }, [modifiedArticle]);
 
   return (

--- a/frontend/components/edit/PublishModal/index.tsx
+++ b/frontend/components/edit/PublishModal/index.tsx
@@ -12,6 +12,7 @@ import Dropdown from '@components/common/Dropdown';
 import ModalButton from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import { IBook, IBookScraps, IScrap } from '@interfaces';
+import { toastSuccess } from '@utils/toast';
 
 import { ArticleWrapper, Label, PublishModalWrapper } from './styled';
 
@@ -73,7 +74,11 @@ export default function PublishModal({ books }: PublishModalProps) {
   };
 
   useEffect(() => {
-    if (createdArticle) router.push('/');
+    if (createdArticle) {
+      const { id, title } = createdArticle.createdArticle;
+      router.push(`/viewer/${selectedBookIndex}/${id}`);
+      toastSuccess(`${title}글이 발행되었습니다.`);
+    }
   }, [createdArticle]);
 
   return (

--- a/frontend/components/study/EditBookModal/index.tsx
+++ b/frontend/components/study/EditBookModal/index.tsx
@@ -151,7 +151,7 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
             <ContentsWrapper>
               <BookContent>Contents</BookContent>
               <EditArticle onClick={handleContentsOnClick}>
-                {isContentsShown ? '완료' : '수정'}
+                {isContentsShown ? '저장' : '수정'}
               </EditArticle>
             </ContentsWrapper>
             <DragArticleWrapper isContentsShown={isContentsShown}>

--- a/frontend/components/study/EditBookModal/index.tsx
+++ b/frontend/components/study/EditBookModal/index.tsx
@@ -151,7 +151,7 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
             <ContentsWrapper>
               <BookContent>Contents</BookContent>
               <EditArticle onClick={handleContentsOnClick}>
-                {isContentsShown ? '저장' : '수정'}
+                {isContentsShown ? '저장' : 'ㅎ수정'}
               </EditArticle>
             </ContentsWrapper>
             <DragArticleWrapper isContentsShown={isContentsShown}>

--- a/frontend/components/study/EditBookModal/index.tsx
+++ b/frontend/components/study/EditBookModal/index.tsx
@@ -151,7 +151,7 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
             <ContentsWrapper>
               <BookContent>Contents</BookContent>
               <EditArticle onClick={handleContentsOnClick}>
-                {isContentsShown ? '저장' : 'ㅎ수정'}
+                {isContentsShown ? '순서저장' : '순서수정'}
               </EditArticle>
             </ContentsWrapper>
             <DragArticleWrapper isContentsShown={isContentsShown}>

--- a/frontend/components/study/UserProfile/styled.ts
+++ b/frontend/components/study/UserProfile/styled.ts
@@ -40,7 +40,7 @@ export const Username = styled(TextLarge)`
 export const UserDescription = styled(TextSmall)`
   width: 400px;
   @media ${(props) => props.theme.tablet} {
-    width: 300px;
+    width: 250px;
   }
 `;
 

--- a/frontend/components/viewer/ScrapModal/index.tsx
+++ b/frontend/components/viewer/ScrapModal/index.tsx
@@ -13,6 +13,7 @@ import Dropdown from '@components/common/Dropdown';
 import ModalButton from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import { IBook, IArticle, IScrap, IBookScraps } from '@interfaces';
+import { toastSuccess } from '@utils/toast';
 
 import { ArticleWrapper, Label, ScrapModalWrapper, WarningLabel } from './styled';
 
@@ -97,6 +98,7 @@ export default function ScrapModal({ bookId, handleModalClose, article }: ScrapM
   useEffect(() => {
     if (createScrapData === undefined) return;
     router.push(`/viewer/${bookId}/${article.id}`);
+    toastSuccess(`${article.title}글이 스크랩되었습니다.`);
     handleModalClose();
   }, [createScrapData]);
 

--- a/frontend/components/viewer/TOC/index.tsx
+++ b/frontend/components/viewer/TOC/index.tsx
@@ -25,6 +25,7 @@ import {
   TocArticleTitle,
   TocCurrentArticle,
   TocOpenButton,
+  TocCurrentText,
 } from './styled';
 
 interface TocProps {
@@ -86,9 +87,9 @@ export default function TOC({
                   </TocArticle>
                 ) : (
                   <TocCurrentArticle key={v.order} className="current">
-                    <TextSmall onClick={handleCurrentArticle} style={{ cursor: 'pointer' }}>
+                    <TocCurrentText onClick={handleCurrentArticle}>
                       {v.order}.{v.article.title}
-                    </TextSmall>
+                    </TocCurrentText>
                     {isArticleShown &&
                       articleToc.map((article) => (
                         <TocArticleTitle

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -112,7 +112,7 @@ export const TocArticleTitle = styled(Link)<{ count: number | undefined }>`
   padding-left: ${(props) => `${props.count}px`};
 
   &:hover {
-    color: #c29880;
+    color: var(--primary-color);
   }
 `;
 

--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import styled from 'styled-components';
 
+import { TextSmall } from '@styles/common';
 import { Flex, FlexColumn, FlexColumnSpaceBetween } from '@styles/layout';
 
 interface TocWrapperProps {
@@ -89,23 +90,30 @@ export const TocArticle = styled(Link)`
   color: inherit;
   display: block;
   margin-bottom: 5px;
+  font-weight: 600;
 `;
 export const TocCurrentArticle = styled.div`
   font-size: 14px;
   line-height: 20px;
   display: block;
   margin-bottom: 5px;
-
-  color: #ca7647;
+  color: var(--primary-color);
+`;
+export const TocCurrentText = styled(TextSmall)`
+  cursor: 'pointer';
+  font-weight: 600;
 `;
 export const TocArticleTitle = styled(Link)<{ count: number | undefined }>`
   font-size: 14px;
   line-height: 20px;
   text-decoration: none;
-  color: #c29880;
   display: block;
   margin-bottom: 5px;
   padding-left: ${(props) => `${props.count}px`};
+
+  &:hover {
+    color: #c29880;
+  }
 `;
 
 export const TocProfile = styled(Link)`

--- a/frontend/utils/toast.ts
+++ b/frontend/utils/toast.ts
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 export const toastError = (message: string) => {
   toast.error(message, {
     position: 'top-right',
-    autoClose: 3000,
+    autoClose: 1000,
     hideProgressBar: false,
     closeOnClick: true,
     pauseOnHover: true,
@@ -16,7 +16,7 @@ export const toastError = (message: string) => {
 export const toastSuccess = (message: string) => {
   toast.success(message, {
     position: 'top-right',
-    autoClose: 3000,
+    autoClose: 1000,
     hideProgressBar: false,
     closeOnClick: true,
     pauseOnHover: true,


### PR DESCRIPTION
## 개요

수정모달, 뷰어페이지 개선 작업

## 변경 사항

- 수정모달 버튼 문구 변경
- 뷰어페이지 TOC UI 변경
- toast 메세제 추가, 링크 수정
- 서제페이지 책 사이즈 고정

## 참고 사항

- 서재 페이지의 책은 우선 주석으로만 처리해뒀습니다. 소개문구의 width는 조정했습니다.
- 지금 보다 더 작아지면, 어짜피 책의 크기때문에 레이아웃이 망가져서 다른 페이지와 동일하다고 판단했습니다.
- 우선 책 크기 고정으로 기존에 이상하게 보이는 부분은 개선할 수 있을 것 같습니다.

## 스크린샷

- 서재페이지

<img width="999" alt="스크린샷 2022-12-12 오후 9 53 52" src="https://user-images.githubusercontent.com/87806611/207051505-46f60913-6fe0-4ebb-a7f8-4604027456be.png">
<img width="1000" alt="스크린샷 2022-12-12 오후 9 54 02" src="https://user-images.githubusercontent.com/87806611/207051577-73d7d22b-0c70-40c5-be0f-fded83c11a9d.png">

- 뷰어페이지
<img width="1004" alt="스크린샷 2022-12-12 오후 9 54 21" src="https://user-images.githubusercontent.com/87806611/207051672-b135adff-7cb2-40dd-9896-f5b4f1ba76a7.png">

- toast메세지
<img width="1002" alt="스크린샷 2022-12-12 오후 9 58 18" src="https://user-images.githubusercontent.com/87806611/207051704-1c448026-d350-4ec1-8a7a-817469fac3d3.png">
<img width="1002" alt="스크린샷 2022-12-12 오후 9 58 45" src="https://user-images.githubusercontent.com/87806611/207051721-d54b5185-64e3-4694-9f4b-f99347ee1002.png">
<img width="1003" alt="스크린샷 2022-12-12 오후 9 58 58" src="https://user-images.githubusercontent.com/87806611/207051730-eae94b9c-fc42-40d0-a412-b359a2454fec.png">

- 수정모달
<img width="423" alt="스크린샷 2022-12-12 오후 10 00 43" src="https://user-images.githubusercontent.com/87806611/207051755-57bbdf66-d93f-450f-afdc-548bf3955b8a.png">
<img width="423" alt="스크린샷 2022-12-12 오후 10 00 52" src="https://user-images.githubusercontent.com/87806611/207051770-4f9925e7-1bf2-44d2-9e07-f186f4a957cf.png">


