### PR TITLE
뷰어 페이지 사이드 바 TOC 개선 및 버그 수정 작업

### DIFF
--- a/frontend/components/viewer/TOC/styled.ts
+++ b/frontend/components/viewer/TOC/styled.ts
@@ -63,11 +63,13 @@ export const TocContainer = styled.div`
   color: var(--grey-01-color);
   background-color: var(--white-color);
   border-radius: 16px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: scroll;
 
   ::-webkit-scrollbar {
     width: 10px;
   }
+
   ::-webkit-scrollbar-thumb {
     background-color: var(--grey-02-color);
     border-radius: 10px;

--- a/frontend/utils/articleConversion.ts
+++ b/frontend/utils/articleConversion.ts
@@ -29,7 +29,7 @@ export const articleConversion = (content: string) => {
     if (v.includes('h1') || v.includes('h2') || v.includes('h3')) {
       const title = v.replace(/<[^>]*>?/g, '');
       const result = v.split('');
-      result.splice(3, 0, ' ', `id=${title}`);
+      result.splice(3, 0, ' ', `id="${title}"`);
       return result.join('');
     }
     return v;


### PR DESCRIPTION
## 개요

뷰어 페이지 사이드 바 TOC 관련 개선 및 버그를 수정했습니다.

## 변경 사항

- 사이드 바 TOC의 가로 스크롤을 제거했습니다.
- 사이드 바 헤딩 태그 내부 텍스트에 공백이 있는 경우 TOC가 동작하지 않는 오류를 수정했습니다.
