### PR TITLE
서재페이지 수정모달 스크랩 버그 수정

### DIFF
--- a/frontend/components/common/DragDrop/Container/index.tsx
+++ b/frontend/components/common/DragDrop/Container/index.tsx
@@ -1,11 +1,10 @@
-import { useEffect, memo, useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import { useDrop } from 'react-dnd';
 
 import update from 'immutability-helper';
 import { useRecoilState } from 'recoil';
 
 import scrapState from '@atoms/scrap';
-import { IScrap } from '@interfaces';
 
 import { ListItem } from '../ListItem';
 import ContainerWapper from './styled';
@@ -15,21 +14,14 @@ const ItemTypes = {
 };
 
 export interface ContainerState {
-  data: IScrap[];
   isContentsShown: boolean;
   isDeleteBtnShown: boolean;
 }
 const DragContainer = memo(function Container({
-  data,
   isContentsShown,
   isDeleteBtnShown,
 }: ContainerState) {
   const [scraps, setScraps] = useRecoilState(scrapState);
-
-  useEffect(() => {
-    if (!data) return;
-    setScraps(data);
-  }, []);
 
   const findScrap = useCallback(
     (id: number) => {

--- a/frontend/components/common/DragDrop/ListItem/index.tsx
+++ b/frontend/components/common/DragDrop/ListItem/index.tsx
@@ -82,8 +82,6 @@ export const ListItem = memo(function Scrap({
   );
 
   const handleMinusBtnClick = () => {
-    // 원본글이 아니면 스크랩에서만 삭제
-    // 원본글이면 실제로 삭제
     if (isOriginal) {
       if (window.confirm('이 글은 원본 글입니다. 정말로 삭제하시겠습니까?')) {
         setEditInfo({

--- a/frontend/components/common/DragDrop/index.tsx
+++ b/frontend/components/common/DragDrop/index.tsx
@@ -13,19 +13,14 @@ export interface EditScrap {
   };
 }
 export interface ContainerState {
-  data: EditScrap[];
   isContentsShown: boolean;
   isDeleteBtnShown: boolean;
 }
 
-export default function DragArticle({ data, isContentsShown, isDeleteBtnShown }: ContainerState) {
+export default function DragArticle({ isContentsShown, isDeleteBtnShown }: ContainerState) {
   return (
     <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
-      <DragContainer
-        data={data}
-        isContentsShown={isContentsShown}
-        isDeleteBtnShown={isDeleteBtnShown}
-      />
+      <DragContainer isContentsShown={isContentsShown} isDeleteBtnShown={isDeleteBtnShown} />
     </DndProvider>
   );
 }

--- a/frontend/components/edit/ModifyModal/index.tsx
+++ b/frontend/components/edit/ModifyModal/index.tsx
@@ -118,11 +118,7 @@ export default function ModifyModal({ books, originalArticle }: ModifyModalProps
       {filteredScraps.length !== 0 && (
         <ArticleWrapper>
           <Label>순서 선택</Label>
-          <DragArticle
-            data={createScrapDropdownItems(filteredScraps)}
-            isContentsShown
-            isDeleteBtnShown={false}
-          />
+          <DragArticle isContentsShown isDeleteBtnShown={false} />
         </ArticleWrapper>
       )}
       <ModalButton theme="primary" onClick={handleModifyBtnClick}>

--- a/frontend/components/edit/PublishModal/index.tsx
+++ b/frontend/components/edit/PublishModal/index.tsx
@@ -94,11 +94,7 @@ export default function PublishModal({ books }: PublishModalProps) {
       {filteredScraps.length !== 0 && (
         <ArticleWrapper>
           <Label>순서 선택</Label>
-          <DragArticle
-            data={createScrapDropdownItems(filteredScraps)}
-            isContentsShown
-            isDeleteBtnShown={false}
-          />
+          <DragArticle isContentsShown isDeleteBtnShown={false} />
         </ArticleWrapper>
       )}
       <ModalButton theme="primary" onClick={handlePublishBtnClick}>

--- a/frontend/components/study/BookListTab/index.tsx
+++ b/frontend/components/study/BookListTab/index.tsx
@@ -7,6 +7,7 @@ import { useRecoilState } from 'recoil';
 import MinusWhite from '@assets/ico_minus_white.svg';
 import curKnottedBookListState from '@atoms/curKnottedBookList';
 import editInfoState from '@atoms/editInfo';
+import scrapState from '@atoms/scrap';
 import Book from '@components/common/Book';
 import FAB from '@components/study/FAB';
 import { IBookScraps } from '@interfaces';
@@ -39,6 +40,7 @@ export default function BookListTab({
 
   const [curKnottedBookList, setCurKnottedBookList] = useRecoilState(curKnottedBookListState);
   const [editInfo, setEditInfo] = useRecoilState(editInfoState);
+  const [_, setScraps] = useRecoilState(scrapState);
 
   const [isModalShown, setModalShown] = useState(false);
   const [curEditBook, setCurEditBook] = useState<IBookScraps | null>(null);
@@ -51,10 +53,12 @@ export default function BookListTab({
 
     setModalShown(true);
     setCurEditBook(curBook);
+    setScraps(curBook.scraps);
   };
 
   const handleModalClose = () => {
     setModalShown(false);
+    setScraps([]);
   };
 
   const handleMinusBtnClick = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {

--- a/frontend/components/study/EditBookModal/index.tsx
+++ b/frontend/components/study/EditBookModal/index.tsx
@@ -41,7 +41,7 @@ interface BookProps {
 }
 
 export default function EditBookModal({ book, handleModalClose }: BookProps) {
-  const { id, title, user, scraps } = book;
+  const { id, title, user } = book;
 
   const { data: imgFile, execute: createImage } = useFetch(createImageApi);
   const { value: titleData, onChange: onTitleChange } = useInput(title);
@@ -106,7 +106,6 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
         },
       ],
     });
-
     handleModalClose();
   };
 
@@ -155,7 +154,7 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
               </EditArticle>
             </ContentsWrapper>
             <DragArticleWrapper isContentsShown={isContentsShown}>
-              <DragArticle data={scraps} isContentsShown={isContentsShown} isDeleteBtnShown />
+              <DragArticle isContentsShown={isContentsShown} isDeleteBtnShown />
             </DragArticleWrapper>
             {isContentsShown && (
               <DragArticleText>드래그앤드롭으로 글의 순서를 변경할 수 있습니다.</DragArticleText>

--- a/frontend/components/viewer/ScrapModal/index.tsx
+++ b/frontend/components/viewer/ScrapModal/index.tsx
@@ -119,11 +119,7 @@ export default function ScrapModal({ bookId, handleModalClose, article }: ScrapM
       {filteredScraps.length !== 0 && (
         <ArticleWrapper>
           <Label>순서 선택</Label>
-          <DragArticle
-            data={createScrapDropdownItems(filteredScraps)}
-            isContentsShown
-            isDeleteBtnShown={false}
-          />
+          <DragArticle isContentsShown isDeleteBtnShown={false} />
         </ArticleWrapper>
       )}
       <ModalButton theme="primary" onClick={handleScrapBtnClick}>


### PR DESCRIPTION
## 개요

서재페이지 수정모달 스크랩 버그 수정

## 변경 사항

- 주말 작업이 반영되면서 수정모달의 스크랩 삭제가 작동하지 않는 문제 해결

## 참고 사항

- 모달안에서의 scraps 전역상태 적용 시점을 변경해서 수정했습니다.
- 민형님께서 최종 수정 완료 버튼시 전역상태를 초기화해주는 로직을 추가 예정입니다.
- 민형님과 협의 완료했습니다.

