### PR TITLE
슬라이더 touch 사선 방향 방지 

### DIFF
--- a/frontend/components/home/Slider/index.tsx
+++ b/frontend/components/home/Slider/index.tsx
@@ -51,7 +51,7 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
     setValue: setSliderNumber,
   } = useSessionStorage(`${title}_sliderNumber`, 1);
 
-  const [touchPositionX, setTouchPositionX] = useState(0);
+  const [touchPosition, setTouchPosition] = useState({ x: 0, y: 0 });
 
   const SkeletonList = Array.from({ length: numberPerPage }, (_, i) => i + 1);
 
@@ -69,15 +69,20 @@ function Slider({ bookList, title, isLoading, numberPerPage }: SliderProps) {
   };
 
   const handleSliderTrackTouchStart = (e: React.TouchEvent) => {
-    setTouchPositionX(e.changedTouches[0].pageX);
+    setTouchPosition({
+      x: e.changedTouches[0].pageX,
+      y: e.changedTouches[0].pageY,
+    });
   };
 
   const handleSliderTrackTouchEnd = (e: React.TouchEvent) => {
-    const distanceX = touchPositionX - e.changedTouches[0].pageX;
-    if (distanceX > 30 && sliderNumber !== sliderIndicatorCount) {
+    const distanceX = touchPosition.x - e.changedTouches[0].pageX;
+    const distanceY = Math.abs(touchPosition.y - e.changedTouches[0].pageY);
+
+    if (distanceX > 40 && distanceY < 10 && sliderNumber !== sliderIndicatorCount) {
       handleRightArrowClick();
     }
-    if (distanceX < -30 && sliderNumber !== 1) {
+    if (distanceX < -40 && distanceY < 10 && sliderNumber !== 1) {
       handleLeftArrowClick();
     }
   };


### PR DESCRIPTION
## 개요

메인 페이지 모바일 환경에서 사선으로 드래그해도 슬라이더가 동작하는 불편함이 있었음. 이를 해결하고자 함

## 변경 사항

- 가로축뿐만 아니라 세로축 값도 처리하는 로직 추가

## 스크린샷

![슬라이더 사선](https://user-images.githubusercontent.com/67371123/207795180-b0cc2224-0bf7-49dd-a35f-9dbc937d91de.gif)

## 관련 이슈

- #303
